### PR TITLE
Acl template adjustments

### DIFF
--- a/templates/aclpolicy.erb
+++ b/templates/aclpolicy.erb
@@ -16,7 +16,7 @@ for:
   <%- elsif ['match','equals','contains'].include?(rule) -%>
     - <%= rule %>:
     <%- action.each do |k,v| -%>
-      <%- if ['kind','path','name','group'].include?(k) -%><%='  '%><%- else -%><%-end-%>
+      <%- if ['kind','path','name','group', 'rundeck_server'].include?(k) -%><%='  '%><%- else -%><%-end-%>
       <%= k %>: <%- if v.is_a? String -%>'<%= v %>'<%-else-%><%= v %><%-end%>
     <%- end -%>
   <%- end -%>

--- a/templates/aclpolicy.erb
+++ b/templates/aclpolicy.erb
@@ -14,8 +14,8 @@ for:
     - <%= rule %>: <%- if action.is_a? String -%>'<%= action %>'<%-else-%><%= action %><%-end%>
     <%- end -%>
   <%- elsif ['match','equals','contains'].include?(rule) -%>
-    <%- action.each do |k,v| -%>
     - <%= rule %>:
+    <%- action.each do |k,v| -%>
       <%- if ['kind','path','name','group'].include?(k) -%><%='  '%><%- else -%><%-end-%>
       <%= k %>: <%- if v.is_a? String -%>'<%= v %>'<%-else-%><%= v %><%-end%>
     <%- end -%>


### PR DESCRIPTION
Hello,

I wanted to do something like this [example](http://rundeck.org/docs/man5/aclpolicy.html#the-aclpolicy-markup-by-example) but I couldn't really get it working with the current ACL template.

I was using the following value for the acl_policies paramter (it's in yaml, since I use automatic hiera binding):
```yaml
rundeck::acl_policies:
  - description: 'mygroup can execute and view executions for job rename-host in the development project'
    context:
      project: 'development'
    for:
      resource:
        - equals:
            kind: 'event'
            allow:
              - 'read'
              - 'create'
      job:
        - equals:
            group: workflows
            name: rename-host
            allow:
              - read
              - run
        - match:
            group: 'workflows/.+'
            allow: run
      node:
        - equals:
            rundeck_server: 'true'
            allow:
              - read
              - run
    by:
      - group:
        - mygroup
```

I want to have a certain group acces to read and run the `rename-host` job, in the `workflows` group, and since that job is referencing other jobs in subgroups under `workflows`, let them execute those. They also need access to the Rundeck node, since the script is executed locally, and without reading the node configuration, jobs cannot be executed. They should also be able to see the results for these executions.

With the current template, I got this:
```yaml
---
description: 'mygroup can execute and view executions in the development project'
context:
  project: 'development'
for:
  resource:
    - equals:
        kind: 'event'
    - equals:
      allow: ["read", "create"]
  job:
    - equals:
        group: 'workflows'
    - equals:
        name: 'rename-host'
    - equals:
      allow: ["read", "run"]
    - match:
        group: 'workflows/.+'
    - match:
      allow: 'run'
  node:
    - equals:
      rundeck_server: 'true'
    - equals:
      allow: ["read", "run"]
by:
  group:
    - 'mygroup'
```
which does not work the way I wanted it to.

After the 2 commits in this change it writes this:
```yaml
---

description: 'mygroup can execute and view executions in the development project'
context:
  project: 'development'
for:
  resource:
    - equals:
        kind: 'event'
      allow: ["read", "create"]
  job:
    - equals:
        group: 'workflows'
        name: 'rename-host'
      allow: ["read", "run"]
    - match:
        group: 'workflows/.+'
      allow: 'run'
  node:
    - equals:
        rundeck_server: 'true'
      allow: ["read", "run"]
by:
  group:
    - 'mygroup'
```
which works as intended