### PR TITLE
should contain JettyCachingLdapLoginModule and be sufficient

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,13 +55,7 @@ class rundeck::config(
   # Checking if we need to deploy realm file
   #  ugly, I know. Fix it if you know better way to do that
   #
-  if 'file' in $auth_types {
-    $_deploy_realm = true
-  }
-  if 'ldap_shared' in $auth_types {
-    $_deploy_realm = true
-  }
-  if 'active_directory_shared' in $auth_types {
+  if 'file' in $auth_types or 'ldap_shared' in $auth_types or 'active_directory_shared' in $auth_types {
     $_deploy_realm = true
   }
   if $_deploy_realm {
@@ -78,26 +72,29 @@ class rundeck::config(
   if 'file' in $auth_types {
     $active_directory_auth_flag = 'sufficient'
     $ldap_auth_flag = 'sufficient'
-  }
-  elsif 'active_directory' in $auth_types {
-    $active_directory_auth_flag = 'required'
-    $ldap_auth_flag = 'sufficient'
-    $ldap_login_module = 'JettyCachingLdapLoginModule'
-  }
-  elsif 'active_directory_shared' in $auth_types {
-    $active_directory_auth_flag = 'requisite'
-    $ldap_auth_flag = 'sufficient'
-    $ldap_login_module = 'JettyCombinedLdapLoginModule'
-  }
-  elsif 'ldap_shared' in $auth_types {
-    $ldap_auth_flag = 'requisite'
-    $ldap_login_module = 'JettyCombinedLdapLoginModule'
-  }
-  else {
-    $ldap_auth_flag = 'required'
-    $ldap_login_module = 'JettyCachingLdapLoginModule'
+  } else {
+    if 'active_directory' in $auth_types {
+      $active_directory_auth_flag = 'required'
+      $ldap_auth_flag = 'sufficient'
+    }
+    elsif 'active_directory_shared' in $auth_types {
+      $active_directory_auth_flag = 'requisite'
+      $ldap_auth_flag = 'sufficient'
+    }
+    elsif 'ldap_shared' in $auth_types {
+      $ldap_auth_flag = 'requisite'
+    }
+    elsif 'ldap' in $auth_types {
+      $ldap_auth_flag = 'required'
+    }
   }
 
+  if 'active_directory' in $auth_types or 'ldap' in $auth_types {
+    $ldap_login_module = 'JettyCachingLdapLoginModule'
+  }
+  elsif 'active_directory_shared' in $auth_types or 'ldap_shared' in $auth_types {
+    $ldap_login_module = 'JettyCombinedLdapLoginModule'
+  }
   file { "${properties_dir}/jaas-auth.conf":
     owner   => $user,
     group   => $group,

--- a/spec/classes/config/global/auth_spec.rb
+++ b/spec/classes/config/global/auth_spec.rb
@@ -21,6 +21,11 @@ describe 'rundeck' do
       content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
     end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
   end
 
   describe 'with empty auth users array' do
@@ -37,6 +42,11 @@ describe 'rundeck' do
     it 'should generate valid content for realm.properties' do
       content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
     end
   end
 
@@ -68,6 +78,133 @@ describe 'rundeck' do
       expect(content).to include('testuser:password,user,deploy')
       expect(content).to include('anotheruser:anotherpassword,user')
     end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
+  end
+
+  describe 'with multiauth ldap and file auth users array' do
+    let(:params) do
+      {
+        :auth_types  => %w(ldap file),
+        :auth_config => {
+          'file' => {
+            'auth_users' => [
+              {
+                'username' => 'testuser',
+                'password' => 'password',
+                'roles'    => %w(user deploy),
+              },
+              {
+                'username' => 'anotheruser',
+                'password' => 'anotherpassword',
+                'roles'    => ['user'],
+              },
+            ],
+          },
+
+          'ldap' => {
+            'debug'                   => 'true',
+            'url'                     => 'localhost:389',
+            'force_binding'           => 'true',
+            'force_binding_use_root'  => 'true',
+            'bind_dn'                 => 'test_rundeck',
+            'bind_password'           => 'abc123',
+            'user_base_dn'            => 'ou=users,ou=accounts,ou=corp,dc=xyz,dc=com',
+            'user_rdn_attribute'      => 'sAMAccountName',
+            'user_id_attribute'       => 'sAMAccountName',
+            'user_password_attribute' => 'unicodePwd',
+            'user_object_class'       => 'user',
+            'role_base_dn'            => 'ou=role based,ou=security,ou=groups,ou=test,dc=xyz,dc=com',
+            'role_name_attribute'     => 'cn',
+            'role_member_attribute'   => 'member',
+            'role_object_class'       => 'group',
+            'supplemental_roles'      => 'user',
+            'nested_groups'           => 'true',
+          },
+        },
+      }
+    end
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      expect(content).to include('admin:admin,user,admin,architect,deploy,build')
+      expect(content).to include('testuser:password,user,deploy')
+      expect(content).to include('anotheruser:anotherpassword,user')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
+
+    it 'should contain JettyCachingLdapLoginModule and be sufficient' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule sufficient')
+    end
+  end
+
+  describe 'with multiauth active_directory and file auth users array' do
+    let(:params) do
+      {
+        :auth_types  => %w(active_directory file),
+        :auth_config => {
+          'file' => {
+            'auth_users' => [
+              {
+                'username' => 'testuser',
+                'password' => 'password',
+                'roles'    => %w(user deploy),
+              },
+              {
+                'username' => 'anotheruser',
+                'password' => 'anotherpassword',
+                'roles'    => ['user'],
+              },
+            ],
+          },
+
+          'active_directory' => {
+            'debug'                   => 'true',
+            'url'                     => 'localhost:389',
+            'force_binding'           => 'true',
+            'force_binding_use_root'  => 'true',
+            'bind_dn'                 => 'test_rundeck',
+            'bind_password'           => 'abc123',
+            'user_base_dn'            => 'ou=users,ou=accounts,ou=corp,dc=xyz,dc=com',
+            'user_rdn_attribute'      => 'sAMAccountName',
+            'user_id_attribute'       => 'sAMAccountName',
+            'user_password_attribute' => 'unicodePwd',
+            'user_object_class'       => 'user',
+            'role_base_dn'            => 'ou=role based,ou=security,ou=groups,ou=test,dc=xyz,dc=com',
+            'role_name_attribute'     => 'cn',
+            'role_member_attribute'   => 'member',
+            'role_object_class'       => 'group',
+            'supplemental_roles'      => 'user',
+            'nested_groups'           => 'true',
+          },
+        },
+      }
+    end
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      expect(content).to include('admin:admin,user,admin,architect,deploy,build')
+      expect(content).to include('testuser:password,user,deploy')
+      expect(content).to include('anotheruser:anotherpassword,user')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
+
+    it 'should contain JettyCachingLdapLoginModule and be sufficient' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule sufficient')
+    end
   end
 
   describe 'with auth user without roles' do
@@ -91,6 +228,11 @@ describe 'rundeck' do
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
       expect(content).to include('testuser:password')
     end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
   end
 
   describe 'backward compatibility (no array of users)' do
@@ -112,6 +254,11 @@ describe 'rundeck' do
       content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
       expect(content).to include('testuser:password,user,deploy')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
     end
   end
 end

--- a/templates/_auth_ad.erb
+++ b/templates/_auth_ad.erb
@@ -1,7 +1,17 @@
 com.dtolabs.rundeck.jetty.jaas.<%= @ldap_login_module %> <%= @active_directory_auth_flag %>
   debug="true"
   contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
-  providerUrl="ldap://<%= @auth_config['active_directory']['server'] %>:<%= @auth_config['active_directory']['port'] %>"
+<%-
+provider_url =
+  if @auth_config['active_directory']['url']
+    @auth_config['active_directory']['url']
+  else
+    server = @auth_config['active_directory']['server']
+    port = @auth_config['active_directory']['port']
+    "ldap://#{server}:#{port}"
+  end
+-%>
+  providerUrl="<%= provider_url %>"
   authenticationMethod="simple"
   forceBindingLogin="<%= @auth_config['active_directory']['force_binding'] %>"
   <%- if @auth_config['active_directory']['bind_dn'] -%>

--- a/templates/_auth_ldap.erb
+++ b/templates/_auth_ldap.erb
@@ -2,13 +2,14 @@ com.dtolabs.rundeck.jetty.jaas.<%= @ldap_login_module %> <%= @ldap_auth_flag %>
   debug="true"
   contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
 <%-
-provider_url =  if @auth_config['ldap']['url']
-                    @auth_config['ldap']['url']
-                else
-                    server = @auth_config['ldap']['server']
-                    port = @auth_config['ldap']['port']
-                    "ldap://#{server}:#{port}"
-                end
+provider_url =
+  if @auth_config['ldap']['url']
+    @auth_config['ldap']['url']
+  else
+    server = @auth_config['ldap']['server']
+    port = @auth_config['ldap']['port']
+    "ldap://#{server}:#{port}"
+  end
 -%>
   providerUrl="<%= provider_url %>"
   authenticationMethod="simple"


### PR DESCRIPTION
added ldap login module if ldap in $auth_types (was previously being defaulted to null for cases when both 'file' and 'ldap' were both in $auth_types)