### PR TITLE
File keystore provisioning

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,13 +55,7 @@ class rundeck::config(
   # Checking if we need to deploy realm file
   #  ugly, I know. Fix it if you know better way to do that
   #
-  if 'file' in $auth_types {
-    $_deploy_realm = true
-  }
-  if 'ldap_shared' in $auth_types {
-    $_deploy_realm = true
-  }
-  if 'active_directory_shared' in $auth_types {
+  if 'file' in $auth_types or 'ldap_shared' in $auth_types or 'active_directory_shared' in $auth_types {
     $_deploy_realm = true
   }
   if $_deploy_realm {
@@ -78,26 +72,29 @@ class rundeck::config(
   if 'file' in $auth_types {
     $active_directory_auth_flag = 'sufficient'
     $ldap_auth_flag = 'sufficient'
-  }
-  elsif 'active_directory' in $auth_types {
-    $active_directory_auth_flag = 'required'
-    $ldap_auth_flag = 'sufficient'
-    $ldap_login_module = 'JettyCachingLdapLoginModule'
-  }
-  elsif 'active_directory_shared' in $auth_types {
-    $active_directory_auth_flag = 'requisite'
-    $ldap_auth_flag = 'sufficient'
-    $ldap_login_module = 'JettyCombinedLdapLoginModule'
-  }
-  elsif 'ldap_shared' in $auth_types {
-    $ldap_auth_flag = 'requisite'
-    $ldap_login_module = 'JettyCombinedLdapLoginModule'
-  }
-  else {
-    $ldap_auth_flag = 'required'
-    $ldap_login_module = 'JettyCachingLdapLoginModule'
+  } else {
+    if 'active_directory' in $auth_types {
+      $active_directory_auth_flag = 'required'
+      $ldap_auth_flag = 'sufficient'
+    }
+    elsif 'active_directory_shared' in $auth_types {
+      $active_directory_auth_flag = 'requisite'
+      $ldap_auth_flag = 'sufficient'
+    }
+    elsif 'ldap_shared' in $auth_types {
+      $ldap_auth_flag = 'requisite'
+    }
+    elsif 'ldap' in $auth_types {
+      $ldap_auth_flag = 'required'
+    }
   }
 
+  if 'active_directory' in $auth_types or 'ldap' in $auth_types {
+    $ldap_login_module = 'JettyCachingLdapLoginModule'
+  }
+  elsif 'active_directory_shared' in $auth_types or 'ldap_shared' in $auth_types {
+    $ldap_login_module = 'JettyCombinedLdapLoginModule'
+  }
   file { "${properties_dir}/jaas-auth.conf":
     owner   => $user,
     group   => $group,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class rundeck::config(
   $acl_policies          = $rundeck::acl_policies,
   $api_policies          = $rundeck::api_policies,
   $rdeck_config_template = $rundeck::rdeck_config_template,
+  $file_keystorage_keys  = $rundeck::file_keystorage_keys,
 ) inherits rundeck::params {
 
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)
@@ -138,10 +139,13 @@ class rundeck::config(
   include '::rundeck::config::global::framework'
   include '::rundeck::config::global::project'
   include '::rundeck::config::global::rundeck_config'
+  include '::rundeck::config::global::file_keystore'
 
   Class[rundeck::config::global::framework] ->
   Class[rundeck::config::global::project] ->
-  Class[rundeck::config::global::rundeck_config]
+  Class[rundeck::config::global::rundeck_config] ->
+  Class[rundeck::config::global::file_keystore]
+
 
   if $ssl_enabled {
     include '::rundeck::config::global::ssl'
@@ -156,4 +160,5 @@ class rundeck::config(
     session_timeout => $session_timeout,
     notify          => Service[$service_name],
   }
+
 }

--- a/manifests/config/file_keystore.pp
+++ b/manifests/config/file_keystore.pp
@@ -1,0 +1,96 @@
+# == Define rundeck::config::file_keystore
+#
+# This definition is used to configure individual Rundeck keys in a file-based
+# key storage facility
+#
+# === Parameters
+#
+# [*value*]
+#   The actual value (password) of the named key
+#
+# [*path*]
+#   The actual value (password) of the named key
+#
+# [*data_type*]
+#   Date type (password, public-key or private-key)
+#
+# [*content_type*]
+#   MIME type of the content
+#
+# [*user*]
+#   default system user for the Rundeck framework
+#
+# [*group*]
+#   default system group for the Rundeck framework
+#
+# [*content_size*]
+#   Size of the content string in bytes
+#
+# [*content_mask*]
+#   Content mask (default is 'content')
+#
+# [*content_creation_time*]
+#   When the key was first created
+#
+# [*auth_created_username*]
+#   User who created the key
+#
+# [*auth_modified_username*]
+#   User who last modified the key
+#
+# [*file_keystorage_dir*]
+#   Base directory for file-based key storage (defaulted to /var/lib/rundeck/var/storage)
+#
+
+define rundeck::config::file_keystore (
+  $value,
+  $path,
+  $data_type,
+  $content_type,
+  $user = $::rundeck::config::user,
+  $group = $::rundeck::config::group,
+  $content_creation_time = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
+  $content_modify_time = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
+  $content_size = size($value),
+  $content_mask = 'content',
+  $auth_created_username = $::rundeck::framework_config['framework.ssh.user'],
+  $auth_modified_username = $::rundeck::framework_config['framework.ssh.user'],
+  $file_keystorage_dir = $::rundeck::file_keystorage_dir,
+) {
+
+  validate_re($data_type, [ 'password', 'public', 'private' ])
+  validate_re($content_type, [ 'application/x-rundeck-data-password', 'application/pgp-keys', 'application/octet-stream' ])
+
+  $key_fqpath = "${file_keystorage_dir}/content/keys/${path}"
+  $meta_fqpath = "${file_keystorage_dir}/meta/keys/${path}"
+
+  exec { "create ${path}_${name} key path":
+    command => "mkdir -m 775 -p ${key_fqpath}; chown -R ${user}:${group} ${key_fqpath}",
+    creates => $key_fqpath,
+  }
+
+  exec { "create ${path}_${name} meta path":
+    command => "mkdir -m 775 -p ${meta_fqpath}; chown -R ${user}:${group} ${meta_fqpath}",
+    creates => $meta_fqpath,
+  }
+
+  File {
+    ensure => present,
+    mode   => '0664',
+    owner  => $user,
+    group  => $group,
+  }
+
+  file { "${key_fqpath}/${name}.${data_type}":
+    content => $value,
+    require => Exec["create ${path}_${name} key path"],
+    replace => false,
+  }
+
+  file { "${meta_fqpath}/${name}.${data_type}":
+    content => template('rundeck/file_keystorage_meta.erb'),
+    require => Exec["create ${path}_${name} meta path"],
+    replace => false,
+  }
+
+}

--- a/manifests/config/global/file_keystore.pp
+++ b/manifests/config/global/file_keystore.pp
@@ -1,0 +1,42 @@
+# == Class rundeck::config::global::file_keystore
+#
+# This private class is called from rundeck::config used to manage the keys of
+# the Rundeck key storage facility, if a file-based backend is used
+#
+class rundeck::config::global::file_keystore(
+  $user = $rundeck::config::user,
+  $group = $rundeck::config::group,
+  $keys = $::rundeck::config::file_keystorage_keys,
+  $file_keystorage_dir = $::rundeck::file_keystorage_dir,
+) {
+
+  File {
+    ensure => directory,
+    mode   => '0775',
+    owner  => $user,
+    group  => $group,
+  }
+
+  file { 'key storage base dir':
+    path => $file_keystorage_dir,
+  } ->
+
+  file { 'content base':
+    path => "${file_keystorage_dir}/content",
+  } ->
+
+  file { 'meta base':
+    path => "${file_keystorage_dir}/meta",
+  } ->
+
+  file { 'content keys':
+    path => "${file_keystorage_dir}/content/keys",
+  } ->
+
+  file { 'meta keys':
+    path => "${file_keystorage_dir}/meta/keys",
+  }
+
+  create_resources(rundeck::config::file_keystore, $keys)
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,6 +150,7 @@ class rundeck (
   $java_home                    = $rundeck::params::java_home,
   $rdeck_home                   = $rundeck::params::rdeck_home,
   $rdeck_config_template        = $rundeck::params::rdeck_config_template,
+  $file_keystorage_keys         = $rundeck::params::file_keystorage_keys,
 ) inherits rundeck::params {
 
   #validate_re($package_ensure, '\d+\.\d+\.\d+')
@@ -179,6 +180,7 @@ class rundeck (
   validate_string($server_web_context)
   validate_absolute_path($rdeck_home)
   validate_rd_policy($acl_policies)
+  validate_hash($file_keystorage_keys)
 
   class { '::rundeck::facts': } ->
   class { '::rundeck::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -277,5 +277,6 @@ class rundeck::params {
 
   $rdeck_config_template = 'rundeck/rundeck-config.erb'
 
-  $file_keystorage_dir = undef
+  $file_keystorage_dir = '/var/lib/rundeck/var/storage/'
+  $file_keystorage_keys = { }
 }

--- a/spec/classes/config/global/auth_spec.rb
+++ b/spec/classes/config/global/auth_spec.rb
@@ -21,6 +21,11 @@ describe 'rundeck' do
       content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
     end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
   end
 
   describe 'with empty auth users array' do
@@ -37,6 +42,11 @@ describe 'rundeck' do
     it 'should generate valid content for realm.properties' do
       content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
     end
   end
 
@@ -68,6 +78,133 @@ describe 'rundeck' do
       expect(content).to include('testuser:password,user,deploy')
       expect(content).to include('anotheruser:anotherpassword,user')
     end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
+  end
+
+  describe 'with multiauth ldap and file auth users array' do
+    let(:params) do
+      {
+        :auth_types  => %w(ldap file),
+        :auth_config => {
+          'file' => {
+            'auth_users' => [
+              {
+                'username' => 'testuser',
+                'password' => 'password',
+                'roles'    => %w(user deploy),
+              },
+              {
+                'username' => 'anotheruser',
+                'password' => 'anotherpassword',
+                'roles'    => ['user'],
+              },
+            ],
+          },
+
+          'ldap' => {
+            'debug'                   => 'true',
+            'url'                     => 'localhost:389',
+            'force_binding'           => 'true',
+            'force_binding_use_root'  => 'true',
+            'bind_dn'                 => 'test_rundeck',
+            'bind_password'           => 'abc123',
+            'user_base_dn'            => 'ou=users,ou=accounts,ou=corp,dc=xyz,dc=com',
+            'user_rdn_attribute'      => 'sAMAccountName',
+            'user_id_attribute'       => 'sAMAccountName',
+            'user_password_attribute' => 'unicodePwd',
+            'user_object_class'       => 'user',
+            'role_base_dn'            => 'ou=role based,ou=security,ou=groups,ou=test,dc=xyz,dc=com',
+            'role_name_attribute'     => 'cn',
+            'role_member_attribute'   => 'member',
+            'role_object_class'       => 'group',
+            'supplemental_roles'      => 'user',
+            'nested_groups'           => 'true',
+          },
+        },
+      }
+    end
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      expect(content).to include('admin:admin,user,admin,architect,deploy,build')
+      expect(content).to include('testuser:password,user,deploy')
+      expect(content).to include('anotheruser:anotherpassword,user')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
+
+    it 'should contain JettyCachingLdapLoginModule and be sufficient' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule sufficient')
+    end
+  end
+
+  describe 'with multiauth active_directory and file auth users array' do
+    let(:params) do
+      {
+        :auth_types  => %w(active_directory file),
+        :auth_config => {
+          'file' => {
+            'auth_users' => [
+              {
+                'username' => 'testuser',
+                'password' => 'password',
+                'roles'    => %w(user deploy),
+              },
+              {
+                'username' => 'anotheruser',
+                'password' => 'anotherpassword',
+                'roles'    => ['user'],
+              },
+            ],
+          },
+
+          'active_directory' => {
+            'debug'                   => 'true',
+            'url'                     => 'localhost:389',
+            'force_binding'           => 'true',
+            'force_binding_use_root'  => 'true',
+            'bind_dn'                 => 'test_rundeck',
+            'bind_password'           => 'abc123',
+            'user_base_dn'            => 'ou=users,ou=accounts,ou=corp,dc=xyz,dc=com',
+            'user_rdn_attribute'      => 'sAMAccountName',
+            'user_id_attribute'       => 'sAMAccountName',
+            'user_password_attribute' => 'unicodePwd',
+            'user_object_class'       => 'user',
+            'role_base_dn'            => 'ou=role based,ou=security,ou=groups,ou=test,dc=xyz,dc=com',
+            'role_name_attribute'     => 'cn',
+            'role_member_attribute'   => 'member',
+            'role_object_class'       => 'group',
+            'supplemental_roles'      => 'user',
+            'nested_groups'           => 'true',
+          },
+        },
+      }
+    end
+
+    it 'should generate valid content for realm.properties' do
+      content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
+      expect(content).to include('admin:admin,user,admin,architect,deploy,build')
+      expect(content).to include('testuser:password,user,deploy')
+      expect(content).to include('anotheruser:anotherpassword,user')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
+
+    it 'should contain JettyCachingLdapLoginModule and be sufficient' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule sufficient')
+    end
   end
 
   describe 'with auth user without roles' do
@@ -91,6 +228,11 @@ describe 'rundeck' do
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
       expect(content).to include('testuser:password')
     end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
+    end
   end
 
   describe 'backward compatibility (no array of users)' do
@@ -112,6 +254,11 @@ describe 'rundeck' do
       content = catalogue.resource('file', '/etc/rundeck/realm.properties')[:content]
       expect(content).to include('admin:admin,user,admin,architect,deploy,build')
       expect(content).to include('testuser:password,user,deploy')
+    end
+
+    it 'should contain PropertyFileLoginModule and be required' do
+      jaas_auth = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+      expect(jaas_auth).to include('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required')
     end
   end
 end

--- a/spec/classes/config/global/file_keystore_spec.rb
+++ b/spec/classes/config/global/file_keystore_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'rundeck' do
+  let(:facts) do
+    {
+      :osfamily        => 'Debian',
+      :fqdn            => 'test.domain.com',
+      :serialnumber    => 0,
+      :rundeck_version => '',
+      :puppetversion   => Puppet.version,
+    }
+  end
+  describe 'add file-based key storage' do
+    let(:params) do
+      {
+        :file_keystorage_dir  => '/var/lib/rundeck/var/storage',
+        :file_keystorage_keys => {
+          'password_key' => {
+            'value'        => 'gobbledygook',
+            'path'         => 'foo/bar',
+            'data_type'    => 'password',
+            'content_type' => 'application/x-rundeck-data-password',
+          },
+          'public_key' => {
+            'value'        => 'ssh-rsa AAAAB3rhwL1EoAIuI3hw9wZL146zjPZ6FIqgZKvO24fpZENYnNfmHn5AuOGBXYGTjeVPMzwV7o0mt3iRWk8J9Ujqvzp45IHfEAE7SO2frEIbfALdcwcNggSReQa0du4nd user@localhost',
+            'path'         => 'foo/bar',
+            'data_type'    => 'public',
+            'content_type' => 'application/pgp-keys',
+          },
+        },
+      }
+    end
+
+    it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password') }
+    it 'should generate valid content for password_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password')[:content]
+      expect(content).to include('gobbledygook')
+    end
+    it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public') }
+    it 'should generate valid meta for password_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/password_key.password')[:content]
+      expect(content).to include('application/x-rundeck-data-password')
+    end
+
+    it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public') }
+    it 'should generate valid content for public_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public')[:content]
+      expect(content).to include('ssh-rsa AAAAB3rhwL1EoAIuI3hw9wZL146zjPZ6FIqgZKvO24fpZENYnNfmHn5AuOGBXYGTjeVPMzwV7o0mt3iRWk8J9Ujqvzp45IHfEAE7SO2frEIbfALdcwcNggSReQa0du4nd user@localhost')
+    end
+    it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public') }
+    it 'should generate valid meta for public_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public')[:content]
+      expect(content).to include('application/pgp-keys')
+    end
+
+  end
+end

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -30,6 +30,10 @@ describe 'rundeck' do
 
           grails.serverURL = "http://test.domain.com:4440"
           rundeck.clusterMode.enabled = "false"
+
+          rundeck.storage.provider."1".config.baseDir = "/var/lib/rundeck/var/storage/"
+          rundeck.storage.provider."1".path = "/"
+          rundeck.storage.provider."1".type = "file"
         CONFIG
 
         it do

--- a/templates/_auth_ad.erb
+++ b/templates/_auth_ad.erb
@@ -1,7 +1,17 @@
 com.dtolabs.rundeck.jetty.jaas.<%= @ldap_login_module %> <%= @active_directory_auth_flag %>
   debug="true"
   contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
-  providerUrl="ldap://<%= @auth_config['active_directory']['server'] %>:<%= @auth_config['active_directory']['port'] %>"
+<%-
+provider_url =
+  if @auth_config['active_directory']['url']
+    @auth_config['active_directory']['url']
+  else
+    server = @auth_config['active_directory']['server']
+    port = @auth_config['active_directory']['port']
+    "ldap://#{server}:#{port}"
+  end
+-%>
+  providerUrl="<%= provider_url %>"
   authenticationMethod="simple"
   forceBindingLogin="<%= @auth_config['active_directory']['force_binding'] %>"
   <%- if @auth_config['active_directory']['bind_dn'] -%>

--- a/templates/_auth_ldap.erb
+++ b/templates/_auth_ldap.erb
@@ -2,13 +2,14 @@ com.dtolabs.rundeck.jetty.jaas.<%= @ldap_login_module %> <%= @ldap_auth_flag %>
   debug="true"
   contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
 <%-
-provider_url =  if @auth_config['ldap']['url']
-                    @auth_config['ldap']['url']
-                else
-                    server = @auth_config['ldap']['server']
-                    port = @auth_config['ldap']['port']
-                    "ldap://#{server}:#{port}"
-                end
+provider_url =
+  if @auth_config['ldap']['url']
+    @auth_config['ldap']['url']
+  else
+    server = @auth_config['ldap']['server']
+    port = @auth_config['ldap']['port']
+    "ldap://#{server}:#{port}"
+  end
 -%>
   providerUrl="<%= provider_url %>"
   authenticationMethod="simple"

--- a/templates/file_keystorage_meta.erb
+++ b/templates/file_keystorage_meta.erb
@@ -1,0 +1,17 @@
+{
+  "Rundeck-content-size":"<%= @content_size %>",
+  <%- if @data_type == "password" -%>
+  "Rundeck-data-type":"<%= @data_type %>",
+  "Rundeck-content-mask":"<%= @content_mask %>",
+  <%- elsif @data_type == "public" -%>
+  "Rundeck-key-type":"<%= @data_type %>",
+  <%- else -%>
+  "Rundeck-key-type":"<%= @data_type %>",
+  "Rundeck-content-mask":"<%= @content_mask %>",
+  <%- end -%>
+  "Rundeck-content-creation-time":"<%= @content_creation_time %>",
+  "Rundeck-auth-created-username":"<%= @auth_created_username %>",
+  "Rundeck-auth-modified-username":"<%= @auth_modified_username %>",
+  "Rundeck-content-modify-time":"<%= @content_modify_time %>",
+  "Rundeck-content-type":"<%= @content_type %>"
+}


### PR DESCRIPTION
Introduces file_keystore.pp, provides automatic provisioning of password-based, public, and private keys via hiera when the default key storage path is provided.  