### PR TITLE
added provisioning of file-based keystores via hiera

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,8 @@ class rundeck::config(
   $acl_policies          = $rundeck::acl_policies,
   $api_policies          = $rundeck::api_policies,
   $rdeck_config_template = $rundeck::rdeck_config_template,
+  $file_keystorage_keys  = $rundeck::file_keystorage_keys,
+
 ) inherits rundeck::params {
 
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)
@@ -138,10 +140,13 @@ class rundeck::config(
   include '::rundeck::config::global::framework'
   include '::rundeck::config::global::project'
   include '::rundeck::config::global::rundeck_config'
+  include '::rundeck::config::global::file_keystore'
 
   Class[rundeck::config::global::framework] ->
   Class[rundeck::config::global::project] ->
-  Class[rundeck::config::global::rundeck_config]
+  Class[rundeck::config::global::rundeck_config] ->
+  Class[rundeck::config::global::file_keystore]
+
 
   if $ssl_enabled {
     include '::rundeck::config::global::ssl'

--- a/manifests/config/file_keystore.pp
+++ b/manifests/config/file_keystore.pp
@@ -1,0 +1,98 @@
+# == Define rundeck::config::file_keystore
+#
+# This type will create the 'content' and 'meta' components for the key to
+# be stored, and currently supports password-based public keys.  Private
+# keys are also supported, but not recommended to be privisioned via this mechanism
+# without the proper security policies for the private key data in place
+#
+# === Parameters
+#
+# [*value*]
+#   The actual value (password) of the named key
+#
+# [*path*]
+#   The actual value (password) of the named key
+#
+# [*data_type*]
+#   Date type (password, public-key or private-key)
+#
+# [*content_type*]
+#   MIME type of the content
+#
+# [*user*]
+#   default system user for the Rundeck framework
+#
+# [*group*]
+#   default system group for the Rundeck framework
+#
+# [*content_size*]
+#   Size of the content string in bytes
+#
+# [*content_mask*]
+#   Content mask (default is 'content')
+#
+# [*content_creation_time*]
+#   When the key was first created
+#
+# [*auth_created_username*]
+#   User who created the key
+#
+# [*auth_modified_username*]
+#   User who last modified the key
+#
+# [*file_keystorage_dir*]
+#   Base directory for file-based key storage (defaulted to /var/lib/rundeck/var/storage)
+#
+
+define rundeck::config::file_keystore (
+  $value,
+  $path,
+  $data_type,
+  $content_type,
+  $user = $::rundeck::config::user,
+  $group = $::rundeck::config::group,
+  $content_creation_time = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
+  $content_modify_time = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
+  $content_size = size($value),
+  $content_mask = 'content',
+  $auth_created_username = $::rundeck::framework_config['framework.ssh.user'],
+  $auth_modified_username = $::rundeck::framework_config['framework.ssh.user'],
+  $file_keystorage_dir = $::rundeck::file_keystorage_dir,
+) {
+
+  validate_re($data_type, [ 'password', 'public', 'private' ])
+  validate_re($content_type, [ 'application/x-rundeck-data-password', 'application/pgp-keys', 'application/octet-stream' ])
+
+  $key_fqpath = "${file_keystorage_dir}/content/keys/${path}"
+  $meta_fqpath = "${file_keystorage_dir}/meta/keys/${path}"
+
+  exec { "create ${path}_${name} key path":
+    command => "mkdir -m 775 -p ${key_fqpath}; chown -R ${user}:${group} ${key_fqpath}",
+    creates => $key_fqpath,
+  }
+
+  exec { "create ${path}_${name} meta path":
+    command => "mkdir -m 775 -p ${meta_fqpath}; chown -R ${user}:${group} ${meta_fqpath}",
+    creates => $meta_fqpath,
+  }
+
+  File {
+    ensure => present,
+    mode   => '0664',
+    owner  => $user,
+    group  => $group,
+  }
+
+  file { "${key_fqpath}/${name}.${data_type}":
+    content => $value,
+    require => Exec["create ${path}_${name} key path"],
+    replace => false,
+  }
+
+  file { "${meta_fqpath}/${name}.${data_type}":
+    content => template('rundeck/file_keystorage_meta.erb'),
+    require => Exec["create ${path}_${name} meta path"],
+    replace => false,
+  }
+
+}

--- a/manifests/config/global/file_keystore.pp
+++ b/manifests/config/global/file_keystore.pp
@@ -1,0 +1,62 @@
+# == Class rundeck::config::global::file_keystore
+#
+# This private class is called from rundeck::config, used to manage the keys of
+# the Rundeck key storage facility if a file-based backend is used
+#
+# === Parameters
+#
+# [*user*]
+#   The Rundeck OS user
+#
+# [*path*]
+#   The Rundeck OS user group
+#
+# [*keys*]
+#   A hash of key data values, with a minimum of the following properties:
+#  * *$value*: the actual value of the key, either the plaintext password string for passwords, or the encrypted public/priviate key
+#  * *$path*: a string representing the relative path of the key to the 'keys' directory
+#  * *$data_type*: the data type of the key, one of 'password', 'public-key' or 'private-key'
+#  * *$content_type*: MIME type of the content, either 'application/x-rundeck-data-password', 'application/pgp-keys' (for public keys)
+#
+# Example:
+# ```
+# {
+#   $key1 => {
+#      $value        => 'secret',
+#      $path         => 'myproject/passwords',
+#      $data_type    => 'password',
+#      $content_type => 'application/x-rundeck-data-password', },
+#   $key2 => {
+#      $value        => 'ssh-rsa Th1sIsn0tRe@alLyAnRSAk3y',
+#      $path         => 'myproject/pubkeys',
+#      $data_type    => 'password',
+#      $content_type => 'application/pgp-keys', },
+# }
+# ```
+#
+#
+# [*file_keystorage_dir*]
+#    The default base directory for file-based key storage
+#
+
+
+class rundeck::config::global::file_keystore(
+  $user = $rundeck::config::user,
+  $group = $rundeck::config::group,
+  $keys = $::rundeck::config::file_keystorage_keys,
+  $file_keystorage_dir = $::rundeck::file_keystorage_dir,
+) {
+
+  File {
+    ensure => directory,
+    mode   => '0775',
+    owner  => $user,
+    group  => $group,
+  }
+
+  file { $file_keystorage_dir: }
+  file { [ "${file_keystorage_dir}/content", "${file_keystorage_dir}/content/keys" ]: }
+  file { [ "${file_keystorage_dir}/meta", "${file_keystorage_dir}/meta/keys" ]: }
+
+  create_resources(rundeck::config::file_keystore, $keys)
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,6 +150,7 @@ class rundeck (
   $java_home                    = $rundeck::params::java_home,
   $rdeck_home                   = $rundeck::params::rdeck_home,
   $rdeck_config_template        = $rundeck::params::rdeck_config_template,
+  $file_keystorage_keys         = $rundeck::params::file_keystorage_keys,
 ) inherits rundeck::params {
 
   validate_array($auth_types)
@@ -177,6 +178,7 @@ class rundeck (
   validate_string($server_web_context)
   validate_absolute_path($rdeck_home)
   validate_rd_policy($acl_policies)
+  validate_hash($file_keystorage_keys)
 
   class { '::rundeck::install': } ->
   class { '::rundeck::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -277,5 +277,6 @@ class rundeck::params {
 
   $rdeck_config_template = 'rundeck/rundeck-config.erb'
 
-  $file_keystorage_dir = undef
+  $file_keystorage_dir = '/var/lib/rundeck/var/storage'
+  $file_keystorage_keys = { }
 }

--- a/spec/classes/config/global/file_keystore_spec.rb
+++ b/spec/classes/config/global/file_keystore_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'rundeck' do
+  let(:facts) do
+    {
+      :osfamily        => 'Debian',
+      :fqdn            => 'test.domain.com',
+      :serialnumber    => 0,
+      :rundeck_version => '',
+      :puppetversion   => Puppet.version,
+    }
+  end
+  describe 'add file-based key storage' do
+    let(:params) do
+      {
+        :file_keystorage_dir  => '/var/lib/rundeck/var/storage',
+        :file_keystorage_keys => {
+          'password_key' => {
+            'value'        => 'gobbledygook',
+            'path'         => 'foo/bar',
+            'data_type'    => 'password',
+            'content_type' => 'application/x-rundeck-data-password',
+          },
+          'public_key' => {
+            'value'        => 'ssh-rsa AAAAB3rhwL1EoAIuI3hw9wZL146zjPZ6FIqgZKvO24fpZENYnNfmHn5AuOGBXYGTjeVPMzwV7o0mt3iRWk8J9Ujqvzp45IHfEAE7SO2frEIbfALdcwcNggSReQa0du4nd user@localhost',
+            'path'         => 'foo/bar',
+            'data_type'    => 'public',
+            'content_type' => 'application/pgp-keys',
+          },
+        },
+      }
+    end
+
+    it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password') }
+    it 'should generate valid content for password_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password')[:content]
+      expect(content).to include('gobbledygook')
+    end
+    it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public') }
+    it 'should generate valid meta for password_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/password_key.password')[:content]
+      expect(content).to include('application/x-rundeck-data-password')
+    end
+
+    it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public') }
+    it 'should generate valid content for public_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public')[:content]
+      expect(content).to include('ssh-rsa AAAAB3rhwL1EoAIuI3hw9wZL146zjPZ6FIqgZKvO24fpZENYnNfmHn5AuOGBXYGTjeVPMzwV7o0mt3iRWk8J9Ujqvzp45IHfEAE7SO2frEIbfALdcwcNggSReQa0du4nd user@localhost')
+    end
+    it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public') }
+    it 'should generate valid meta for public_key' do
+      content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public')[:content]
+      expect(content).to include('application/pgp-keys')
+    end
+  end
+end

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -30,6 +30,10 @@ describe 'rundeck' do
 
           grails.serverURL = "http://test.domain.com:4440"
           rundeck.clusterMode.enabled = "false"
+
+          rundeck.storage.provider."1".config.baseDir = "/var/lib/rundeck/var/storage"
+          rundeck.storage.provider."1".path = "/"
+          rundeck.storage.provider."1".type = "file"
         CONFIG
 
         it do

--- a/templates/file_keystorage_meta.erb
+++ b/templates/file_keystorage_meta.erb
@@ -1,0 +1,17 @@
+{
+  "Rundeck-content-size":"<%= @content_size %>",
+  <%- if @data_type == "password" -%>
+  "Rundeck-data-type":"<%= @data_type %>",
+  "Rundeck-content-mask":"<%= @content_mask %>",
+  <%- elsif @data_type == "public" -%>
+  "Rundeck-key-type":"<%= @data_type %>",
+  <%- else -%>
+  "Rundeck-key-type":"<%= @data_type %>",
+  "Rundeck-content-mask":"<%= @content_mask %>",
+  <%- end -%>
+  "Rundeck-content-creation-time":"<%= @content_creation_time %>",
+  "Rundeck-auth-created-username":"<%= @auth_created_username %>",
+  "Rundeck-auth-modified-username":"<%= @auth_modified_username %>",
+  "Rundeck-content-modify-time":"<%= @content_modify_time %>",
+  "Rundeck-content-type":"<%= @content_type %>"
+}


### PR DESCRIPTION
Added mechanism to automate provisioning of password and public keys for file-based keystorage in rundeck::config::global::file_keystore, with key data provided via hiera.

Example of key data hash:
```
 {
   $key1 => {
      $value        => 'secret',
      $path         => 'myproject/passwords',
      $data_type    => 'password',
      $content_type => 'application/x-rundeck-data-password', },
   $key2 => {
      $value        => 'ssh-rsa Th1sIsn0tRe@alLyAnRSAk3y',
      $path         => 'myproject/pubkeys',
      $data_type    => 'public-key',
      $content_type => 'application/pgp-keys', },
}
```