### PR TITLE
Add support for customizing profile

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,6 +41,7 @@ class rundeck::config(
   $acl_policies                = $rundeck::acl_policies,
   $api_policies                = $rundeck::api_policies,
   $rdeck_config_template       = $rundeck::rdeck_config_template,
+  $rdeck_profile_template      = $rundeck::rdeck_profile_template,
   $file_keystorage_keys        = $rundeck::file_keystorage_keys,
   $manage_default_admin_policy = $rundeck::manage_default_admin_policy,
   $manage_default_api_policy   = $rundeck::manage_default_api_policy,
@@ -146,7 +147,7 @@ class rundeck::config(
     owner   => $user,
     group   => $group,
     mode    => '0640',
-    content => template('rundeck/profile.erb'),
+    content => template($rdeck_profile_template),
     notify  => Service[$service_name],
     require => File[$properties_dir],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,6 +124,14 @@
 # [*manage_default_api_policy*]
 #   Boolean value if set to true enables default api policy management
 #
+# [*rdeck_config_template*]
+#
+#   Allows you to override the rundeck-config template
+#
+# [*rdeck_profile_template*]
+#
+#   Allows you to override the profile template
+#
 class rundeck (
   $package_ensure               = $rundeck::params::package_ensure,
   $package_source               = $rundeck::params::package_source,
@@ -170,6 +178,7 @@ class rundeck (
   $java_home                    = $rundeck::params::java_home,
   $rdeck_home                   = $rundeck::params::rdeck_home,
   $rdeck_config_template        = $rundeck::params::rdeck_config_template,
+  $rdeck_profile_template       = $rundeck::params::rdeck_profile_template,
   $file_keystorage_keys         = $rundeck::params::file_keystorage_keys,
   $manage_default_admin_policy  = $rundeck::params::manage_default_admin_policy,
   $manage_default_api_policy    = $rundeck::params::manage_default_api_policy,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -278,6 +278,7 @@ class rundeck::params {
   $session_timeout = 30
 
   $rdeck_config_template = 'rundeck/rundeck-config.erb'
+  $rdeck_profile_template = 'rundeck/profile.erb'
 
   $file_keystorage_keys = { }
   $file_keystorage_dir = "${framework_config['framework.var.dir']}/storage"


### PR DESCRIPTION
Following https://github.com/voxpupuli/puppet-rundeck/pull/109,  I've created a patch but this time for customizing `profile`.
By default, it will still use `rundeck/profile.erb`