### PR TITLE
Support preauthenticated mode config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,6 +35,7 @@ class rundeck::config(
   $key_storage_type            = $rundeck::key_storage_type,
   $service_name                = $rundeck::service_name,
   $mail_config                 = $rundeck::mail_config,
+  $preauthenticated_config     = $rundeck::preauthenticated_config,
   $security_config             = $rundeck::security_config,
   $security_role               = $rundeck::security_role,
   $session_timeout             = $rundeck::session_timeout,

--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -7,20 +7,21 @@
 # This private class is called from rundeck::config used to manage the rundeck-config properties
 #
 class rundeck::config::global::rundeck_config(
-  $rd_loglevel           = $rundeck::config::loglevel,
-  $rdeck_base            = $rundeck::config::rdeck_base,
-  $rss_enabled           = $rundeck::config::rss_enabled,
-  $clustermode_enabled   = $rundeck::config::clustermode_enabled,
-  $grails_server_url     = $rundeck::config::grails_server_url,
-  $properties_dir        = $rundeck::config::properties_dir,
-  $file_keystorage_dir   = $rundeck::config::file_keystorage_dir,
-  $projects_storage_type = $rundeck::config::projects_storage_type,
-  $key_storage_type      = $rundeck::config::key_storage_type,
-  $user                  = $rundeck::config::user,
-  $group                 = $rundeck::config::group,
-  $mail_config           = $rundeck::config::mail_config,
-  $security_config       = $rundeck::config::security_config,
-  $rdeck_config_template = $rundeck::config::rdeck_config_template,
+  $rd_loglevel             = $rundeck::config::loglevel,
+  $rdeck_base              = $rundeck::config::rdeck_base,
+  $rss_enabled             = $rundeck::config::rss_enabled,
+  $clustermode_enabled     = $rundeck::config::clustermode_enabled,
+  $grails_server_url       = $rundeck::config::grails_server_url,
+  $properties_dir          = $rundeck::config::properties_dir,
+  $file_keystorage_dir     = $rundeck::config::file_keystorage_dir,
+  $projects_storage_type   = $rundeck::config::projects_storage_type,
+  $key_storage_type        = $rundeck::config::key_storage_type,
+  $user                    = $rundeck::config::user,
+  $group                   = $rundeck::config::group,
+  $mail_config             = $rundeck::config::mail_config,
+  $preauthenticated_config = $rundeck::config::preauthenticated_config,
+  $security_config         = $rundeck::config::security_config,
+  $rdeck_config_template   = $rundeck::config::rdeck_config_template,
 ) {
 
   $properties_file = "${properties_dir}/rundeck-config.groovy"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,6 +97,10 @@
 # [*mail_config*]
 #  A hash of the notification email configuraton.
 #
+# [*preauthenticated_config*]
+#
+#  A hash of the rundeck preauthenticated config mode
+#
 # [*security_config*]
 #  A hash of the rundeck security configuration.
 #
@@ -167,6 +171,7 @@ class rundeck (
   $service_script               = $rundeck::params::service_script,
   $service_config               = $rundeck::params::service_config,
   $mail_config                  = $rundeck::params::mail_config,
+  $preauthenticated_config      = $rundeck::params::preauthenticated_config,
   $security_config              = $rundeck::params::security_config,
   $security_role                = $rundeck::params::security_role,
   $session_timeout              = $rundeck::params::session_timeout,
@@ -205,6 +210,7 @@ class rundeck (
   validate_string($service_name)
   validate_string($package_ensure)
   validate_hash($mail_config)
+  validate_hash($preauthenticated_config)
   validate_string($user)
   validate_string($group)
   validate_string($server_web_context)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -263,6 +263,12 @@ class rundeck::params {
 
   $resource_sources = {}
 
+  $preauthenticated_config = {
+    'enabled'       => false,
+    'attributeName' => 'REMOTE_USER_GROUPS',
+    'delimiter'     => ':',
+  }
+
   $server_web_context = undef
   $jvm_args = '-Xmx1024m -Xms256m -server'
 

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -36,6 +36,10 @@ describe 'rundeck' do
           rundeck.storage.provider."1".type = "file"
           rundeck.storage.provider."1".config.baseDir = "/var/lib/rundeck/var/storage"
           rundeck.storage.provider."1".path = "/"
+
+          rundeck.security.authorization.preauthenticated.enabled = "false"
+          rundeck.security.authorization.preauthenticated.attributeName = "REMOTE_USER_GROUPS"
+          rundeck.security.authorization.preauthenticated.delimiter = ":"
         CONFIG
 
         it do

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -42,3 +42,7 @@ rundeck.storage.provider."1".config.baseDir = "<%= @file_keystorage_dir %>"
 rundeck.storage.provider."1".type = "db"
 <%- end -%>
 rundeck.storage.provider."1".path = "/"
+
+rundeck.security.authorization.preauthenticated.enabled = "<%= @preauthenticated_config['enabled']%>"
+rundeck.security.authorization.preauthenticated.attributeName = "<%= @preauthenticated_config['attributeName']%>"
+rundeck.security.authorization.preauthenticated.delimiter = "<%= @preauthenticated_config['delimiter']%>"


### PR DESCRIPTION
Since v.2.5 Rundeck supports  preauthenticated mode http://rundeck.org/docs/administration/authenticating-users.html#preauthenticated-mode

This patch adds the necessary bits to configure it.