### PR TITLE
Remove auth-constraint from web.xml if preauthenticated mode enabled

### DIFF
--- a/manifests/config/global/web.pp
+++ b/manifests/config/global/web.pp
@@ -33,4 +33,20 @@ class rundeck::config::global::web (
     incl    => $rundeck::params::web_xml,
     changes => [ "set web-app/session-config/session-timeout/#text '${session_timeout}'" ],
   }
+
+  if $rundeck::preauthenticated_config['enabled'] {
+    augeas { 'rundeck/web.xml/security-constraint/auth-constraint':
+      lens    => 'Xml.lns',
+      incl    => $rundeck::params::web_xml,
+      changes => [ 'rm web-app/security-constraint/auth-constraint' ],
+    }
+  }
+  else {
+    augeas { 'rundeck/web.xml/security-constraint/auth-constraint/role-name':
+      lens    => 'Xml.lns',
+      incl    => $rundeck::params::web_xml,
+      changes => [ "set web-app/security-constraint[last()+1]/auth-constraint/role-name/#text '*'" ],
+      onlyif  => 'match web-app/security-constraint/auth-constraint/role-name size == 0',
+    }
+  }
 }


### PR DESCRIPTION
When I opened the PR for configuring preauthenticated mode (https://github.com/voxpupuli/puppet-rundeck/pull/175), I forgot this:

[From the rundeck docs:](http://rundeck.org/docs/administration/authenticating-users.html#preauthenticated-mode)
`The file WEB-INF/web.xml inside the war contents must be modified to remove the <auth-constraint> element. This disables the behavior which causes the Container to trigger its authentication mechanism when a user browses to a Rundeck page requiring authorizaton.`

This patch should take of it.
