### PR TITLE
Ensure rundeck directories are owned by $user and $group

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -89,10 +89,35 @@ class rundeck::install(
   }
 
   file { $rdeck_home:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
-    mode   => '0755',
+    ensure  => directory,
+    recurse => true,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
+  }
+
+  file { $rundeck::params::service_logs_dir:
+    ensure  => directory,
+    recurse => true,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
+  }
+
+  file { $rundeck::params::framework_config['framework.etc.dir']:
+    ensure  => directory,
+    recurse => true,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
+  }
+
+  file { '/var/rundeck/':
+    ensure  => directory,
+    recurse => true,
+    owner   => $user,
+    group   => $group,
+    mode    => '0640',
   }
 
   ensure_resource(file, $projects_dir, {'ensure' => 'directory', 'owner' => $user, 'group' => $group})


### PR DESCRIPTION
As you may know, I'm trying to configure Rundeck to use [preauthenticated-mode](http://rundeck.org/docs/administration/authenticating-users.html#preauthenticated-mode).

One of the issues I'm facing now is that I need to be sure that all Rundeck's directories are owned by the `$user` and `$group` rundeck has been installed as. The current code does not ensure it.

This patch is meant to fix this issue.

I set 0640 for everything since this is what it was applied on /etc/rundeck but I'm not against changing it to 644 (default) or any other.