### PR TITLE
Added management of scm-import.properties

### DIFF
--- a/manifests/config/global/file_keystore.pp
+++ b/manifests/config/global/file_keystore.pp
@@ -29,7 +29,7 @@
 #   $key2 => {
 #      $value        => 'ssh-rsa Th1sIsn0tRe@alLyAnRSAk3y',
 #      $path         => 'myproject/pubkeys',
-#      $data_type    => 'password',
+#      $data_type    => 'public',
 #      $content_type => 'application/pgp-keys', },
 # }
 # ```

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -262,6 +262,7 @@ class rundeck::params {
   $truststore_password = 'adminadmin'
 
   $resource_sources = {}
+  $scm_import_properties = {}
 
   $preauthenticated_config = {
     'enabled'       => false,

--- a/spec/classes/config/global/file_keystore_spec.rb
+++ b/spec/classes/config/global/file_keystore_spec.rb
@@ -31,24 +31,26 @@ describe 'rundeck' do
       }
     end
 
+    # content and meta data for passwords
     it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password') }
-    it 'should generate valid content for password_key' do
+    it 'should generate valid *content* for password_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password')[:content]
       expect(content).to include('gobbledygook')
     end
-    it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public') }
-    it 'should generate valid meta for password_key' do
+    it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/password_key.password') }
+    it 'should generate valid *meta* for password_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/password_key.password')[:content]
       expect(content).to include('application/x-rundeck-data-password')
     end
 
+    # content and meta data for public keys
     it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public') }
-    it 'should generate valid content for public_key' do
+    it 'should generate valid *content* for public_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public')[:content]
       expect(content).to include('ssh-rsa AAAAB3rhwL1EoAIuI3hw9wZL146zjPZ6FIqgZKvO24fpZENYnNfmHn5AuOGBXYGTjeVPMzwV7o0mt3iRWk8J9Ujqvzp45IHfEAE7SO2frEIbfALdcwcNggSReQa0du4nd user@localhost')
     end
     it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public') }
-    it 'should generate valid meta for public_key' do
+    it 'should generate valid *meta* for public_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public')[:content]
       expect(content).to include('application/pgp-keys')
     end

--- a/spec/classes/config/global/scm_properties_spec.rb
+++ b/spec/classes/config/global/scm_properties_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'rundeck' do
+  let(:facts) do
+    {
+      :osfamily        => 'Debian',
+      :fqdn            => 'test.domain.com',
+      :serialnumber    => 0,
+      :rundeck_version => '',
+      :puppetversion   => Puppet.version
+    }
+  end
+  describe 'add scm properties to project' do
+    project_hash = {
+      'project_1' => {
+        'scm_import_properties' => {
+          'scm.import.config.useFilePattern'        => 'true',
+          'scm.import.config.strictHostKeyChecking' => 'no',
+          'scm.import.config.filePattern'           => 'SBO/*',
+          'scm.import.config.url'                   => 'git.repo.com/project_1.jobs.git',
+          'scm.import.config.format'                => 'yaml',
+          'scm.import.config.dir'                   => '/var/lib/rundeck/projects/proect_1/scm',
+          'scm.import.config.pathTemplate'          => '${job.project}/${job.group}${job.name}-${job.id}.${config.format}',
+          'scm.import.config.sshPrivateKeyPath'     => '',
+          'scm.import.config.gitPasswordPath'       => '',
+          'scm.import.config.branch'                => 'master',
+          'scm.import.enabled'                      => 'false',
+          'scm.import.roles.0'                      => 'user',
+          'scm.import.type'                         => 'git-import',
+          'scm.import.username'                     => '',
+          'scm.import.roles.count'                  => '3',
+          'scm.import.trackedItems.count'           => '0'
+        }
+      }
+    }
+    let(:params) do
+      {
+        :projects => project_hash
+      }
+    end
+
+    # content and meta data for passwords
+    it { should contain_file('/var/lib/rundeck/projects/project_1/etc/scm-import.properties') }
+    project_hash['project_1']['scm_import_properties'].each do |key, value|
+      it 'should generate valid content for scm-import.properties' do
+        content = catalogue.resource('file', '/var/lib/rundeck/projects/project_1/etc/scm-import.properties')[:content]
+        expect(content).to include("#{key} = #{value}")
+      end
+    end
+  end
+end

--- a/spec/defines/config/project_spec.rb
+++ b/spec/defines/config/project_spec.rb
@@ -15,6 +15,7 @@ describe 'rundeck::config::project', :type => :define do
             },
             :file_copier_provider => 'jsch-scp',
             :resource_sources => {},
+            :scm_import_properties => {},
             :node_executor_provider => 'jsch-ssh',
             :user  => 'rundedck',
             :group => 'rundeck'

--- a/templates/scm-import.properties.erb
+++ b/templates/scm-import.properties.erb
@@ -1,0 +1,3 @@
+<%- @scm_import_properties.sort.each do |k,v| -%>
+<%= k %> = <%= v %>
+<%- end -%>


### PR DESCRIPTION
#### Overview 
* added management of scm-import.properties files via hiera, which is used by Rundeck SCM for project jobs; does not (yet) execute the 'git clone' which actually retrieves the jobs onto the Rundeck server
* fixed some ambiguity in tests for file_keystore_spec.rb

#### Tests
* https://github.com/dalisch/puppet-rundeck/blob/manage_scm_import_properties/spec/classes/config/global/scm_properties_spec.rb

#### Example Hiera structure
```
rundeck::projects:
  my_project:
    scm_import_properties:
      scm.import.config.useFilePattern: true
      scm.import.config.strictHostKeyChecking: 'no'
      scm.import.config.filePattern: 'proect_1/*'
      scm.import.config.url: 'https\://github.com/rundeck/rundeck-jobs-test.git'
      scm.import.config.format: yaml
      scm.import.config.dir: /var/lib/rundeck/projects/my_project/scm
      scm.import.config.pathTemplate: '${job.project}/${job.group}${job.name}-${job.id}.${config.format}'
      scm.import.config.sshPrivateKeyPath: ''
      scm.import.config.gitPasswordPath: ''
      scm.import.config.branch: master
      scm.import.enabled: false
      scm.import.roles.0: user
      scm.import.type: git-import
      scm.import.username: ''
      scm.import.roles.count: 1
      scm.import.trackedItems.count: 0
```