### PR TITLE
refactored file permissions management

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,6 +50,12 @@ class rundeck::config(
   $user                        = $rundeck::user,
 ) inherits rundeck::params {
 
+  File {
+    owner  => $user,
+    group  => $group,
+    mode   => '0640',
+  }
+
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)
   $auth_config      = deep_merge($rundeck::params::auth_config, $rundeck::auth_config)
 
@@ -57,8 +63,6 @@ class rundeck::config(
   $rdeck_base     = $framework_config['rdeck.base']
   $projects_dir   = $framework_config['framework.projects.dir']
   $properties_dir = $framework_config['framework.etc.dir']
-
-  ensure_resource('file', $properties_dir, {'ensure' => 'directory', 'owner' => $user, 'group' => $group} )
 
   #
   # Checking if we need to deploy realm file
@@ -72,9 +76,6 @@ class rundeck::config(
 
   if $_deploy_realm {
     file { "${properties_dir}/realm.properties":
-      owner   => $user,
-      group   => $group,
-      mode    => '0640',
       content => template($realm_template),
       require => File[$properties_dir],
       notify  => Service[$service_name],
@@ -108,17 +109,11 @@ class rundeck::config(
     $ldap_login_module = 'JettyCombinedLdapLoginModule'
   }
   file { "${properties_dir}/jaas-auth.conf":
-    owner   => $user,
-    group   => $group,
-    mode    => '0640',
     content => template($auth_template),
     require => File[$properties_dir],
   }
 
   file { "${properties_dir}/log4j.properties":
-    owner   => $user,
-    group   => $group,
-    mode    => '0640',
     content => template('rundeck/log4j.properties.erb'),
     notify  => Service[$service_name],
     require => File[$properties_dir],
@@ -162,7 +157,6 @@ class rundeck::config(
   Class[rundeck::config::global::project] ->
   Class[rundeck::config::global::rundeck_config] ->
   Class[rundeck::config::global::file_keystore]
-
 
   if $ssl_enabled {
     include '::rundeck::config::global::ssl'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,6 +24,12 @@ class rundeck::install(
   $user = $rundeck::user
   $group = $rundeck::group
 
+  File {
+    owner  => $user,
+    group  => $group,
+    mode   => '0640',
+  }
+
   case $::osfamily {
     'RedHat': {
       if $manage_yum_repo == true {
@@ -90,36 +96,20 @@ class rundeck::install(
 
   file { $rdeck_home:
     ensure  => directory,
-    recurse => true,
-    owner   => $user,
-    group   => $group,
-    mode    => '0640',
+  } ~>
+  file { $framework_config['framework.ssh.keypath']:
+    mode    => '0600',
   }
 
-  file { $rundeck::params::service_logs_dir:
+  file { $rundeck::service_logs_dir:
     ensure  => directory,
-    recurse => true,
-    owner   => $user,
-    group   => $group,
-    mode    => '0640',
-  }
-
-  file { $rundeck::params::framework_config['framework.etc.dir']:
-    ensure  => directory,
-    recurse => true,
-    owner   => $user,
-    group   => $group,
-    mode    => '0640',
   }
 
   file { '/var/rundeck/':
     ensure  => directory,
     recurse => true,
-    owner   => $user,
-    group   => $group,
-    mode    => '0640',
   }
 
-  ensure_resource(file, $projects_dir, {'ensure' => 'directory', 'owner' => $user, 'group' => $group})
-  ensure_resource(file, $plugin_dir, {'ensure'   => 'directory', 'owner' => $user, 'group' => $group})
+  ensure_resource(file, $projects_dir, {'ensure' => 'directory'})
+  ensure_resource(file, $plugin_dir, {'ensure'   => 'directory'})
 }


### PR DESCRIPTION
#### Overview
* refactored file resource management by utilizing resource default for file permissions and ownership
* removed 'recurse' property on all files in $rdeck_base and subdirs
* resubmission of [PR#202](https://github.com/voxpupuli/puppet-rundeck/pull/202) now that the master branch is happy again

#### Bug fixes
* https://github.com/voxpupuli/puppet-rundeck/issues/196
