### PR TITLE
Add Rundeck GUI customization properties

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,6 +19,7 @@ class rundeck::config(
   $file_keystorage_keys        = $rundeck::file_keystorage_keys,
   $grails_server_url           = $rundeck::grails_server_url,
   $group                       = $rundeck::group,
+  $gui_config                  = $rundeck::gui_config,
   $java_home                   = $rundeck::java_home,
   $jvm_args                    = $rundeck::jvm_args,
   $key_password                = $rundeck::key_password,

--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -22,6 +22,7 @@ class rundeck::config::global::rundeck_config(
   $rss_enabled             = $rundeck::config::rss_enabled,
   $security_config         = $rundeck::config::security_config,
   $user                    = $rundeck::config::user,
+  $gui_config              = $rundeck::config::gui_config,
 ) {
 
   $properties_file = "${properties_dir}/rundeck-config.groovy"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,9 @@
 # [*group*]
 #  The group permission that rundeck is installed as.
 #
+# [*gui_config*]
+#  Hash of properties for customizing the [Rundeck GUI](http://rundeck.org/docs/administration/gui-customization.html)
+#
 # [*java_home*]
 #  Set the home directory of java.
 #
@@ -142,6 +145,7 @@ class rundeck (
   $framework_config             = $rundeck::params::framework_config,
   $grails_server_url            = $rundeck::params::grails_server_url,
   $group                        = $rundeck::params::group,
+  $gui_config                   = $rundeck::params::gui_config,
   $java_home                    = $rundeck::params::java_home,
   $jvm_args                     = $rundeck::params::jvm_args,
   $key_password                 = $rundeck::params::key_password,
@@ -191,6 +195,7 @@ class rundeck (
   validate_bool($rss_enabled)
   validate_bool($clustermode_enabled)
   validate_string($grails_server_url)
+  validate_hash($gui_config)
   validate_hash($database_config)
   validate_absolute_path($keystore)
   validate_re($key_storage_type, [ '^db$', '^file$' ])

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -263,6 +263,7 @@ class rundeck::params {
 
   $resource_sources = {}
   $scm_import_properties = {}
+  $gui_config = {}
 
   $preauthenticated_config = {
     'enabled'       => false,

--- a/spec/classes/config/global/gui_config_spec.rb
+++ b/spec/classes/config/global/gui_config_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'rundeck' do
+  context 'supported operating systems' do
+    %w(Debian RedHat).each do |osfamily|
+      gui_config_hash = {
+        'rundeck.gui.title'         => 'Test title',
+        'rundeck.gui.brand.html'    => '<b>App</b>',
+        'rundeck.gui.logo'          => 'test-logo.png',
+        'rundeck.gui.login.welcome' => 'Weclome to Rundeck'
+      }
+
+      let(:facts) do
+        {
+          :osfamily        => osfamily,
+          :fqdn            => 'test.domain.com',
+          :serialnumber    => 0,
+          :rundeck_version => '',
+          :puppetversion   => Puppet.version
+        }
+      end
+
+      let(:params) do
+        {
+          :gui_config => gui_config_hash
+        }
+      end
+
+      # content and meta data for passwords
+      it 'should generate gui_config content for rundeck-config.groovy' do
+        content = catalogue.resource('file', '/etc/rundeck/rundeck-config.groovy')[:content]
+        expect(content).to include('rundeck.gui.title = "Test title"')
+        expect(content).to include('rundeck.gui.brand.html = "<b>App</b>"')
+        expect(content).to include('rundeck.gui.logo = "test-logo.png"')
+        expect(content).to include('rundeck.gui.login.welcome = "Weclome to Rundeck"')
+      end
+    end
+  end
+end

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -40,6 +40,7 @@ describe 'rundeck' do
           rundeck.security.authorization.preauthenticated.enabled = "false"
           rundeck.security.authorization.preauthenticated.attributeName = "REMOTE_USER_GROUPS"
           rundeck.security.authorization.preauthenticated.delimiter = ":"
+
         CONFIG
 
         it do

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -46,3 +46,7 @@ rundeck.storage.provider."1".path = "/"
 rundeck.security.authorization.preauthenticated.enabled = "<%= @preauthenticated_config['enabled']%>"
 rundeck.security.authorization.preauthenticated.attributeName = "<%= @preauthenticated_config['attributeName']%>"
 rundeck.security.authorization.preauthenticated.delimiter = "<%= @preauthenticated_config['delimiter']%>"
+
+<%- @gui_config.sort.each do |k,v| -%>
+<%= k %> = "<%= v %>"
+<%- end -%>


### PR DESCRIPTION
### Overview
Added hash for rundeck.gui.* properties to be added to rundeck-config.groovy, to facilitate [Rundeck GUI customization](http://rundeck.org/docs/administration/gui-customization.html).

### Highlights
* new parameter $gui_config is a hash that is intended to contain all of the rundeck.gui.* properties; values are added to the end of rundeck-config.groovy

### Tests
https://travis-ci.org/dalisch/puppet-rundeck/builds/118297584