### PR TITLE
Add note and example about using an external MySQL DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,27 @@ The group permission that rundeck is installed as.
 ###Configuring shared authentication credentials
 To perform LDAP authentication and file authorization see example examples/ldap\_shared.pp
 
+###Configure a MySQL database
+
+To use an external MySQL database, the `database_config` hash must be set to
+override the default values which result in a local file based storage.  To
+enable `key` and `project` storage in the database, you must also set the two
+parameters associated parameters.
+
+```puppet
+class { '::rundeck':
+  key_storage_type      => 'db',
+  projects_storage_type => 'db',
+  database_config       => {
+    'type'              => 'mysql',
+    'url'               => $db_url,
+    'username'          => 'rundeck',
+    'password'          => $db_pass,
+    'driverClassName'   => 'com.mysql.jdbc.Driver',
+  }
+}
+```
+
 ##Reference
 
 ###Classes


### PR DESCRIPTION
Without this change, there is no example for users who wish to use an
existing, external database.  Here we update the README to reflect what
it takes to get the configuration on disk in a state that will enable an
external MySQL database for key and project storage.