### PR TITLE
Add CentOS 7 to tested platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ This module is tested on the following platforms:
 
 * CentOS 5
 * CentOS 6
+* CentOS 7
 * Ubuntu 12.04
 * Ubuntu 14.04
 


### PR DESCRIPTION
This one-line change is an assertion that Rundeck has been installed and
is functional on CentOS 7.  Since CentOS 7 is already included in the
supported platforms, this change is merely to keep documentation up to
date.