### PR TITLE
Amend default policy for full storage control

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -98,6 +98,9 @@ class rundeck::params {
         'project' => [
           {'allow' => '*'},
         ],
+        'storage' => [
+          {'allow' => '*'},
+        ],
       },
       'by' => [{
         'group' => ['admin']

--- a/spec/classes/config/global/aclpolicyfile_spec.rb
+++ b/spec/classes/config/global/aclpolicyfile_spec.rb
@@ -41,6 +41,8 @@ for:
     - allow: '*'
   project:
     - allow: '*'
+  storage:
+    - allow: '*'
 by:
   group:
     - 'admin'


### PR DESCRIPTION
Without this change, storage is omited from the default policy for
admin, leaving the administrative user unable to modify storage items,
like 'keys/'.

This change amends the default policy to allow the admin user full
control over storage.