### PR TITLE
Automate configuration of SCM export properties in a project

### DIFF
--- a/manifests/config/project.pp
+++ b/manifests/config/project.pp
@@ -55,7 +55,8 @@ define rundeck::config::project (
   $node_executor_settings = {},
   $projects_dir           = undef,
   $resource_sources       = $rundeck::resource_sources,
-  $scm_import_properties  = $rundeck::scm_import_properties,
+  $scm_import_properties  = {},
+  $scm_export_properties  = {},
   $ssh_keypath            = undef,
   $user                   = $rundeck::user,
 ) {
@@ -85,6 +86,7 @@ define rundeck::config::project (
   $project_dir = "${projects_dir_real}/${name}"
   $properties_file = "${project_dir}/etc/project.properties"
   $scm_import_properties_file = "${project_dir}/etc/scm-import.properties"
+  $scm_export_properties_file = "${project_dir}/etc/scm-export.properties"
 
   file {  $project_dir :
     ensure  => directory,
@@ -104,6 +106,15 @@ define rundeck::config::project (
   file { $scm_import_properties_file:
     ensure  => present,
     content => template('rundeck/scm-import.properties.erb'),
+    owner   => $user,
+    group   => $group,
+    require => File["${project_dir}/etc"],
+    replace => false,
+  }
+
+  file { $scm_export_properties_file:
+    ensure  => present,
+    content => template('rundeck/scm-export.properties.erb'),
     owner   => $user,
     group   => $group,
     require => File["${project_dir}/etc"],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -267,7 +267,6 @@ class rundeck::params {
   $truststore_password = 'adminadmin'
 
   $resource_sources = {}
-  $scm_import_properties = {}
   $gui_config = {}
 
   $preauthenticated_config = {

--- a/spec/classes/config/global/scm_spec.rb
+++ b/spec/classes/config/global/scm_spec.rb
@@ -30,6 +30,23 @@ describe 'rundeck' do
           'scm.import.username'                     => '',
           'scm.import.roles.count'                  => '3',
           'scm.import.trackedItems.count'           => '0'
+        },
+        'scm_export_properties' => {
+          'scm.export.enabled'                      => 'false',
+          'scm.export.config.format'                => 'yaml',
+          'scm.export.config.dir'                   => '/var/lib/rundeck/projects/project_1/scm',
+          'scm.export.config.url'                   => 'git.repo.com/project_1.jobs.git',
+          'scm.export.config.branch'                => 'master',
+          'scm.export.config.pathTemplate'          => '{job.project}/${job.group}${job.name}-${job.id}.${config.format}',
+          'scm.export.config.strictHostKeyChecking' => 'no',
+          'scm.export.config.gitPasswordPath'       => '',
+          'scm.export.config.sshPrivateKeyPath'     => 'keys/${project}/users/scm/${user.login}.private',
+          'scm.export.roles.count'                  => '2',
+          'scm.export.roles.1'                      => 'user',
+          'scm.export.type'                         => 'git-export',
+          'scm.export.username'                     => '${user.username}',
+          'scm.export.config.committerName'         => '${user.fullName}',
+          'scm.export.config.committerEmail'        => '${user.email}'
         }
       }
     }
@@ -44,6 +61,12 @@ describe 'rundeck' do
     project_hash['project_1']['scm_import_properties'].each do |key, value|
       it 'should generate valid content for scm-import.properties' do
         content = catalogue.resource('file', '/var/lib/rundeck/projects/project_1/etc/scm-import.properties')[:content]
+        expect(content).to include("#{key} = #{value}")
+      end
+    end
+    project_hash['project_1']['scm_export_properties'].each do |key, value|
+      it 'should generate valid content for scm-export.properties' do
+        content = catalogue.resource('file', '/var/lib/rundeck/projects/project_1/etc/scm-export.properties')[:content]
         expect(content).to include("#{key} = #{value}")
       end
     end

--- a/spec/defines/config/project_spec.rb
+++ b/spec/defines/config/project_spec.rb
@@ -15,7 +15,6 @@ describe 'rundeck::config::project', :type => :define do
             },
             :file_copier_provider => 'jsch-scp',
             :resource_sources => {},
-            :scm_import_properties => {},
             :node_executor_provider => 'jsch-ssh',
             :user  => 'rundedck',
             :group => 'rundeck'

--- a/templates/scm-export.properties.erb
+++ b/templates/scm-export.properties.erb
@@ -1,0 +1,3 @@
+<%- @scm_export_properties.sort.each do |k,v| -%>
+<%= k %> = <%= v %>
+<%- end -%>


### PR DESCRIPTION
### Overview
* similar to existing scm_import_properties, new hash parameter scm_export_properties added in `rundeck::config::project` when it is desired to pre-specify the SCM configuration for exporting Rundeck jobs
* properties used to populate scm-export.properties via `scm-export.properties.erb` template