### PR TITLE
Simple fix qualify command

### DIFF
--- a/manifests/config/file_keystore.pp
+++ b/manifests/config/file_keystore.pp
@@ -73,14 +73,14 @@ define rundeck::config::file_keystore (
 
   exec { "create ${path}_${name} key path":
     provider => shell,
-    command => "mkdir -m 775 -p ${key_fqpath}; chown -R ${user}:${group} ${key_fqpath}",
-    creates => $key_fqpath,
+    command  => "mkdir -m 775 -p ${key_fqpath}; chown -R ${user}:${group} ${key_fqpath}",
+    creates  => $key_fqpath,
   }
 
   exec { "create ${path}_${name} meta path":
     provider => shell,
-    command => "mkdir -m 775 -p ${meta_fqpath}; chown -R ${user}:${group} ${meta_fqpath}",
-    creates => $meta_fqpath,
+    command  => "mkdir -m 775 -p ${meta_fqpath}; chown -R ${user}:${group} ${meta_fqpath}",
+    creates  => $meta_fqpath,
   }
 
   File {

--- a/manifests/config/file_keystore.pp
+++ b/manifests/config/file_keystore.pp
@@ -72,11 +72,13 @@ define rundeck::config::file_keystore (
   $meta_fqpath = "${file_keystorage_dir}/meta/keys/${path}"
 
   exec { "create ${path}_${name} key path":
+    provider => shell,
     command => "mkdir -m 775 -p ${key_fqpath}; chown -R ${user}:${group} ${key_fqpath}",
     creates => $key_fqpath,
   }
 
   exec { "create ${path}_${name} meta path":
+    provider => shell,
     command => "mkdir -m 775 -p ${meta_fqpath}; chown -R ${user}:${group} ${meta_fqpath}",
     creates => $meta_fqpath,
   }

--- a/spec/classes/config/global/file_keystore_spec.rb
+++ b/spec/classes/config/global/file_keystore_spec.rb
@@ -33,14 +33,14 @@ describe 'rundeck' do
 
     # content and meta data for passwords
     it { should contain_exec('create foo/bar_password_key key path').with_provider('shell') }
-    it { should contain_exec('create foo/bar_password_key key path').with_command("mkdir -m 775 -p /var/lib/rundeck/var/storage/content/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/content/keys/foo/bar") }
+    it { should contain_exec('create foo/bar_password_key key path').with_command('mkdir -m 775 -p /var/lib/rundeck/var/storage/content/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/content/keys/foo/bar') }
     it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password') }
     it 'should generate valid *content* for password_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password')[:content]
       expect(content).to include('gobbledygook')
     end
     it { should contain_exec('create foo/bar_password_key meta path').with_provider('shell') }
-    it { should contain_exec('create foo/bar_password_key meta path').with_command("mkdir -m 775 -p /var/lib/rundeck/var/storage/meta/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/meta/keys/foo/bar") }
+    it { should contain_exec('create foo/bar_password_key meta path').with_command('mkdir -m 775 -p /var/lib/rundeck/var/storage/meta/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/meta/keys/foo/bar') }
     it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/password_key.password') }
     it 'should generate valid *meta* for password_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/password_key.password')[:content]
@@ -49,14 +49,14 @@ describe 'rundeck' do
 
     # content and meta data for public keys
     it { should contain_exec('create foo/bar_public_key key path').with_provider('shell') }
-    it { should contain_exec('create foo/bar_public_key key path').with_command("mkdir -m 775 -p /var/lib/rundeck/var/storage/content/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/content/keys/foo/bar") }
+    it { should contain_exec('create foo/bar_public_key key path').with_command('mkdir -m 775 -p /var/lib/rundeck/var/storage/content/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/content/keys/foo/bar') }
     it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public') }
     it 'should generate valid *content* for public_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/content/keys/foo/bar/public_key.public')[:content]
       expect(content).to include('ssh-rsa AAAAB3rhwL1EoAIuI3hw9wZL146zjPZ6FIqgZKvO24fpZENYnNfmHn5AuOGBXYGTjeVPMzwV7o0mt3iRWk8J9Ujqvzp45IHfEAE7SO2frEIbfALdcwcNggSReQa0du4nd user@localhost')
     end
     it { should contain_exec('create foo/bar_public_key meta path').with_provider('shell') }
-    it { should contain_exec('create foo/bar_public_key meta path').with_command("mkdir -m 775 -p /var/lib/rundeck/var/storage/meta/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/meta/keys/foo/bar") }
+    it { should contain_exec('create foo/bar_public_key meta path').with_command('mkdir -m 775 -p /var/lib/rundeck/var/storage/meta/keys/foo/bar; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/meta/keys/foo/bar') }
     it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public') }
     it 'should generate valid *meta* for public_key' do
       content = catalogue.resource('file', '/var/lib/rundeck/var/storage/meta/keys/foo/bar/public_key.public')[:content]


### PR DESCRIPTION
### Description

Trying to add a custom file_keystorage_dir I found out this error:
Error: Failed to apply catalog: Validation of Exec[create _public key path] failed: 'mkdir -m 775 -p /var/lib/rundeck/var/storage/content/keys/; chown -R rundeck:rundeck /var/lib/rundeck/var/storage/content/keys/' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/rundeck/manifests/config/file_keystore.pp:77
I fix this adding provider => shell to the exec at /etc/puppet/modules/rundeck/manifests/config/file_keystore.pp:77

### Tasks

- [x] I have added provider => shell to exec resource to get a qualified command
- [x] I have tested this change in Vagrant in a Centos machine