### PR TITLE
Simple fix aclpolicy.erb template

### DIFF
--- a/templates/aclpolicy.erb
+++ b/templates/aclpolicy.erb
@@ -11,8 +11,8 @@ for:
   <%- if %w( allow deny ).include?(type) -%>
     <% if first_key -%>-<%- else %> <% end -%> <%= type %>: <%- if action.is_a? String -%>'<%= action %>'<%-else-%><%= action %><%-end%>
   <%- elsif %w( match equals contains ).include?(type) -%>
-    <%- action.each do |k,v| -%>
     <% if first_key -%>-<%- else %> <% end -%> <%= type %>:
+    <%- action.each do |k,v| -%>
       <%- if %w( kind path name nodename group rundeck_server ).include?(k) -%><%='  '%><%- else -%><%-end-%>
       <%= k %>: <%- if v.is_a? String -%>'<%= v %>'<%-else-%><%= v %><%-end%>
     <%- end -%>


### PR DESCRIPTION
### Description

Simple fix on aclpolicy.erb template.
The template produce a wrong structure:
  resource:
    - equals:
        kind: job
    - equals:
      allow: [create] # allow create jobs

The correct one should be:
  resource:
    - equals:
        kind: job
      allow: [create] # allow create jobs

### Tasks

- [x] I have tested this change in Vagrant