### PR TITLE
Add param to configure service state

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,6 +121,9 @@
 # [*service_name*]
 #  The name of the rundeck service.
 #
+#  [*service_ensure*]
+#  State of the rundeck service (defaults to 'running')
+#
 # [*session_timeout*]
 #  Session timeout is an expired time limit for a logged in Rundeck GUI user which as been inactive for a period of time.
 #
@@ -186,6 +189,7 @@ class rundeck (
   $service_manage               = $rundeck::params::service_manage,
   $service_name                 = $rundeck::params::service_name,
   $service_script               = $rundeck::params::service_script,
+  $service_ensure               = $rundeck::params::service_ensure,
   $session_timeout              = $rundeck::params::session_timeout,
   $ssl_enabled                  = $rundeck::params::ssl_enabled,
   $truststore                   = $rundeck::params::truststore,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class rundeck::params {
   $service_manage = false
   $service_config = ''
   $service_script = ''
+  $service_ensure = 'running'
 
   $rdeck_base = '/var/lib/rundeck'
   $rdeck_home = '/var/lib/rundeck'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,6 +12,7 @@ class rundeck::service(
   $service_manage = $rundeck::service_manage,
   $service_name   = $rundeck::service_name,
   $service_script = $rundeck::service_script,
+  $service_ensure = $rundeck::service_ensure,
 ) {
 
   if $caller_module_name != $module_name {
@@ -33,7 +34,7 @@ class rundeck::service(
   }
 
   service { $service_name:
-    ensure     => running,
+    ensure     => $service_ensure,
     enable     => true,
     hasstatus  => true,
     hasrestart => true,


### PR DESCRIPTION
We are running Rundeck in Preauthenticated Mode with a different Servlet Container (Tomcat).
Because of this, we need to ensure that `rundeckd` service is not running (stopped) in favor of the tomcat service, which is the one actually service launching rundeck.

This patch makes this possible without changing the default behavior.