### PR TITLE
Do not write non-existent mail configuration

### DIFF
--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -16,14 +16,24 @@ dataSource {
   <%- end -%>
 }
 
-<%- if !@mail_config.empty? %>
+<%- if !@mail_config.empty? && @mail_config.keys != ['defaults.from'] %>
 grails {
   mail {
+    <%- if @mail_config['host'] -%>
     host = "<%= @mail_config['host'] %>"
+    <%- end -%>
+    <%- if @mail_config['username'] -%>
     username = "<%= @mail_config['username'] %>"
+    <%- end -%>
+    <%- if @mail_config['port'] -%>
     port = <%= @mail_config['port'] %>
+    <%- end -%>
+    <%- if @mail_config['password'] -%>
     password = "<%= @mail_config['password'] %>"
+    <%- end -%>
+    <%- if @mail_config['props'] -%>
     props = [<% @mail_config['props'].each do |k,v| -%>"<%= k %>":"<%= v %>",<% end %>]
+    <%- end -%>
   }
 }
 <%- end -%>


### PR DESCRIPTION
The template shall not reference keys in the mail_config hash, that might not be there.

In my use case, the only mail_config attribute I want to use is the from address. This has to be inside the *mail_config* hash. When the hash had no other keys, the template still tried to write all the other values, such as *server* and *port*, and worse, do `mail_config['props'].each`, calling `each` on a nil object.

I also had to change the condition after checking whether mail_config is empty or not, otherwise the template generated 
```
grails {
  mail {
  }
}
```
in the config file.