### PR TITLE
fixed management of $file_keystore_dir

### DIFF
--- a/manifests/config/file_keystore.pp
+++ b/manifests/config/file_keystore.pp
@@ -61,6 +61,7 @@ define rundeck::config::file_keystore (
 
   validate_re($data_type, [ 'password', 'public', 'private' ])
   validate_re($content_type, [ 'application/x-rundeck-data-password', 'application/pgp-keys', 'application/octet-stream' ])
+  ensure_resource('file', [ $file_keystorage_dir ], { 'ensure' => 'directory' })
 
   if !$content_size {
     $content_size_value = size($value)

--- a/spec/classes/config/global/file_keystore_spec.rb
+++ b/spec/classes/config/global/file_keystore_spec.rb
@@ -31,6 +31,9 @@ describe 'rundeck' do
       }
     end
 
+    # base key storage directory needs to be there first
+    it { should contain_file('/var/lib/rundeck/var/storage') }
+
     # content and meta data for passwords
     it { should contain_file('/var/lib/rundeck/var/storage/content/keys/foo/bar/password_key.password').with_content(/gobbledygook/) }
     it { should contain_file('/var/lib/rundeck/var/storage/meta/keys/foo/bar/password_key.password').with_content(%r{application/x-rundeck-data-password}) }


### PR DESCRIPTION
### Summary

* re-introduced management of base $file_keystorage_dir (it was originally working after this PR: https://github.com/voxpupuli/puppet-rundeck/pull/172).  Added test to prevent future occurrences.