### PR TITLE
Example manifest to demo-install Rundeck on EL7

### DIFF
--- a/examples/demo_install_el7.pp
+++ b/examples/demo_install_el7.pp
@@ -1,0 +1,27 @@
+# Simple demo-install of rundeck on EL7 (CentOS, RHEL)
+#
+# Pre-requisites:
+# - Installed modules
+# puppet module install puppetlabs-java
+# puppet module install puppet-rundeck
+# puppet module install crayfishx-firewalld
+# - $::fqdn fact needs to be working
+#
+# After installation:
+# - Webinterface on http://${::fqdn}:4440
+# - Login with admin/admin
+#
+
+include ::java
+include ::rundeck
+include ::firewalld
+
+firewalld_port { 'Rundeck HTTP port':
+  ensure   => present,
+  zone     => 'public',
+  port     => 4440,
+  protocol => 'tcp',
+}
+
+Class['java'] -> Class['rundeck']
+


### PR DESCRIPTION
Simple example for demo purposes howto install Rundeck
on EL7 (RedHat, CentOS).