### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-rundeck",
   "version": "3.0.1-rc0",
   "author": "voxpupuli",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "summary": "Module for managing the installatation and configuration of the rundeck orchestration tool",
   "source": "https://github.com/voxpupuli/puppet-rundeck.git",
   "project_page": "https://github.com/voxpupuli/puppet-rundeck",


### PR DESCRIPTION
LICENSE file has MIT license, metadata.json has had Apache-2.0
for quite some time