### PR TITLE
Allow not managing user and group creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,9 @@
 # [*manage_default_api_policy*]
 #  Boolean value if set to true enables default api policy management
 #
+# [*manage_user_group*]
+#  Boolean value if set to true lets this module manage the user and group resources
+#
 # [*package_ensure*]
 #  Ensure the state of the rundeck package, either present, absent or a specific version
 #
@@ -186,6 +189,7 @@ class rundeck (
   $manage_default_admin_policy  = $rundeck::params::manage_default_admin_policy,
   $manage_default_api_policy    = $rundeck::params::manage_default_api_policy,
   $manage_yum_repo              = $rundeck::params::manage_yum_repo,
+  $manage_user_group            = $rundeck::params::manage_user_group,
   $package_ensure               = $rundeck::params::package_ensure,
   $package_source               = $rundeck::params::package_source,
   $preauthenticated_config      = $rundeck::params::preauthenticated_config,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,6 +24,7 @@ class rundeck::install(
 
   $user = $rundeck::user
   $group = $rundeck::group
+  $manage_user_group = $rundeck::manage_user_group
 
   File {
     owner  => $user,
@@ -76,23 +77,25 @@ class rundeck::install(
     }
   }
 
-  if $group == 'rundeck' {
-    ensure_resource('group', 'rundeck', { 'ensure' => 'present' } )
-  } else {
-    ensure_resource('group', $group, { 'ensure' => 'present' } )
+  if $manage_user_group {
+    if $group == 'rundeck' {
+      ensure_resource('group', 'rundeck', { 'ensure' => 'present' } )
+    } else {
+      ensure_resource('group', $group, { 'ensure' => 'present' } )
 
-    group { 'rundeck':
-      ensure => absent,
+      group { 'rundeck':
+        ensure => absent,
+      }
     }
-  }
 
-  if $user == 'rundeck' {
-    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
-  } else {
-    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
+    if $user == 'rundeck' {
+      ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
+    } else {
+      ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
 
-    user { 'rundeck':
-      ensure => absent,
+      user { 'rundeck':
+        ensure => absent,
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -241,6 +241,8 @@ class rundeck::params {
   $user = 'rundeck'
   $group = 'rundeck'
 
+  $manage_user_group = true
+
   $loglevel = 'INFO'
   $rss_enabled = false
 


### PR DESCRIPTION
In certain scenarios being able to manage uid and gid of users and groups is important.

Because the module manages the  user and group for rundeck, it's not possible to specify those.

This patch adds a boolean value to still be able to pass user and group for permissions, but give the possibility to manage those resources elsewhere.

Signed-off-by: Christophe Vanlancker <christophe.vanlancker@inuits.eu>