### PR TITLE
Add missing 'rd_auditlevel' parameter to config.pp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,6 +36,7 @@ class rundeck::config(
   $projects_organization        = $rundeck::projects_default_org,
   $projects_storage_type        = $rundeck::projects_storage_type,
   $rd_loglevel                  = $rundeck::rd_loglevel,
+  $rd_auditlevel                = $rundeck::rd_auditlevel,
   $rdeck_config_template        = $rundeck::rdeck_config_template,
   $rdeck_profile_template       = $rundeck::rdeck_profile_template,
   $realm_template               = $rundeck::realm_template,


### PR DESCRIPTION
The 'rd_autidlevel' parameter was missing from the parameter list in config.pp. This meant that the template did not have access to it and thus resulting in a missing value for the log4j configuration (e.g. ', audit').