### PR TITLE
Add missing node resource properties to acltemplate

### DIFF
--- a/templates/aclpolicy.erb
+++ b/templates/aclpolicy.erb
@@ -13,7 +13,7 @@ for:
   <%- elsif %w( match equals contains ).include?(type) -%>
     <% if first_key -%>-<%- else %> <% end -%> <%= type %>:
     <%- action.each do |k,v| -%>
-      <%- if %w( kind path name nodename group tags rundeck_server ).include?(k) -%><%='  '%><%- else -%><%-end-%>
+      <%- if %w( kind path name nodename username hostname description osName osFamily osVersion osArch group tags rundeck_server ).include?(k) -%><%='  '%><%- else -%><%-end-%>
       <%= k %>: <%- if v.is_a? String -%>'<%= v %>'<%-else-%><%= v %><%-end%>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
as defined in the rundeck documentation, there are default node resource properties. i would like to add those to the aclpolicy template to ensure proper indentation
http://rundeck.org/docs/administration/access-control-policy.html#node-resource-properties

