### PR TITLE
WIP: Use FQDN based random value for 'rundeck.server.uuid' when 'serialnumber' fact is not present

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,11 @@ class rundeck::params {
   $rdeck_home = '/var/lib/rundeck'
   $service_logs_dir = '/var/log/rundeck'
 
+  $rdeck_uuid = defined('$::serialnumber') ? {
+    true    => $::serialnumber,
+    default => fqdn_rand_string(10)
+  }
+
   $framework_config = {
     'framework.server.name'     => $::fqdn,
     'framework.server.hostname' => $::fqdn,
@@ -55,7 +60,7 @@ class rundeck::params {
     'framework.ssh.keypath'     => '/var/lib/rundeck/.ssh/id_rsa',
     'framework.ssh.user'        => 'rundeck',
     'framework.ssh.timeout'     => '0',
-    'rundeck.server.uuid'       => $::serialnumber,
+    'rundeck.server.uuid'       => $rdeck_uuid,
   }
 
   $auth_types = ['file']

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'rundeck' do
+  describe '\'serialnumber\' fact present' do
+    let(:facts) do
+      {
+        osfamily: 'RedHat',
+        serialnumber: 'rea8CTp2ed'
+      }
+    end
+
+    it { should contain_file('/etc/rundeck/framework.properties') }
+    it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
+      content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
+      expect(content).to include('rundeck.server.uuid = rea8CTp2ed')
+    end
+  end
+
+  describe '\'serialnumber\' fact not present' do
+    let(:facts) do
+      {
+        osfamily: 'RedHat',
+        fqdn: 'somehost.example.com'
+      }
+    end
+
+    it { should contain_file('/etc/rundeck/framework.properties') }
+    it 'generates a random uuid for \'rundeck.server.uuid\'' do
+      content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
+      expect(content).to include('rundeck.server.uuid = 5pWDei3ENj')
+    end
+  end
+end


### PR DESCRIPTION
When the 'serialnumber' fact is not present the 'rundeck.server.uuid'
setting is set to 'undef'. Also when the 'strict_variables' setting
is set to true, the Puppet parser will fail if the 'serialnumber' fact
is not present.

When the 'serialnumber' fact is present it will still use it, if not it
will fallback to using a random value based on the FQDN. Therefor this
change should not break existing installations.
