### PR TITLE
Add EC2 Nodes options and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The name of the project for which this resource in intended to be a part.
 The sequential number of the resource within the project.
 
 #####`source_type`
-The source type where resources will come from: file, directory, url or script.
+The source type where resources will come from: file, directory, url, aws-ec2, or script.
 
 #####`include_server_node`
 Boolean value to decide whether or not to include the server node in your list of avaliable nodes.
@@ -243,6 +243,15 @@ The format of the resource that will procesed, either resourcexml or resourceyam
 
 #####`url`
 When the url source_type is specified this is the path to that url.
+
+#####`mapping_params`
+When the aws-ec2 source_type is specified, use these [mapping params](https://github.com/rundeck-plugins/rundeck-ec2-nodes-plugin#mapping-definition). The value should be a semicolon-delimited string.
+
+#####`use_default_mapping`
+When the aws-ec2 source_type is specified, this boolean value indicates whether to use the default mapping params in addition to those specified in `mapping_params`.
+
+#####`running_only`
+When the aws-ec2 source_type is specified, this boolean value indicates whether to show all EC2 instances or only running ones.
 
 #####`url_timeout`
 An integer value in seconds that rundeck will wait for resources from the url before timing out.

--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ When the aws-ec2 source_type is specified, this boolean value indicates whether 
 #####`running_only`
 When the aws-ec2 source_type is specified, this boolean value indicates whether to show all EC2 instances or only running ones.
 
+#####`endpoint`
+When the aws-ec2 source_type is specified, this string represents the [regional API endpoint](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region) to use. Omitting this will use the default region.
+
+#####`refresh_interval`
+When the aws-ec2 source_type is specified, this controls how frequently the EC2 nodes are refreshed. Default is 30.
+
 #####`url_timeout`
 An integer value in seconds that rundeck will wait for resources from the url before timing out.
 

--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -80,6 +80,8 @@ define rundeck::config::resource_source(
   $url_cache                          = $rundeck::params::url_cache,
   $url_timeout                        = $rundeck::params::url_timeout,
   $use_default_mapping                = true,
+  $endpoint                           = '',
+  $refresh_interval                   = '30',
   $puppet_enterprise_host             = '',
   $puppet_enterprise_port             = '',
   $puppet_enterprise_ssl_dir          = '',
@@ -320,6 +322,22 @@ define rundeck::config::resource_source(
         section => '',
         setting => "resources.source.${number}.config.runningOnly",
         value   => bool2str($running_only),
+        require => File[$properties_file],
+      }
+      ini_setting { "resources.source.${number}.config.endpoint":
+        ensure  => present,
+        path    => $properties_file,
+        section => '',
+        setting => "resources.source.${number}.config.endpoint",
+        value   => $endpoint,
+        require => File[$properties_file],
+      }
+      ini_setting { "resources.source.${number}.config.refreshInterval":
+        ensure  => present,
+        path    => $properties_file,
+        section => '',
+        setting => "resources.source.${number}.config.refreshInterval",
+        value   => $refresh_interval,
         require => File[$properties_file],
       }
     }


### PR DESCRIPTION
Adding `endpoint` and `refresh_interval` as options to `rundeck::config::resource_source`. Also updated the README to reflect these changes and the ones from #113. I'm going to close #276 shortly.
