### PR TITLE
Fix/framework.server.url (use framework.server.hostname instead of fqdn fact)

### DIFF
--- a/manifests/config/global/framework.pp
+++ b/manifests/config/global/framework.pp
@@ -18,11 +18,11 @@ class rundeck::config::global::framework(
 
   if $ssl_enabled and $ssl_port == '' {
     $framework_config_port = { 'framework.server.port' => '4443' }
-    $framework_config_url = { 'framework.server.url' => "http://${framework_config_base['framework.server.hostname']}:4443" }
+    $framework_config_url = { 'framework.server.url' => "https://${framework_config_base['framework.server.hostname']}:4443" }
   }
   elsif $ssl_enabled and $ssl_port != '' {
     $framework_config_port = { 'framework.server.port' => $ssl_port }
-    $framework_config_url = { 'framework.server.url' => "http://${framework_config_base['framework.server.hostname']}:${ssl_port}" }
+    $framework_config_url = { 'framework.server.url' => "https://${framework_config_base['framework.server.hostname']}:${ssl_port}" }
   }
   else {
     $framework_config_port = { 'framework.server.port' => '4440' }

--- a/manifests/config/global/framework.pp
+++ b/manifests/config/global/framework.pp
@@ -18,11 +18,11 @@ class rundeck::config::global::framework(
 
   if $ssl_enabled and $ssl_port == '' {
     $framework_config_port = { 'framework.server.port' => '4443' }
-    $framework_config_url = { 'framework.server.url' => "https://${::fqdn}:4443" }
+    $framework_config_url = { 'framework.server.url' => "http://${framework_config_base['framework.server.hostname']}:4443" }
   }
   elsif $ssl_enabled and $ssl_port != '' {
     $framework_config_port = { 'framework.server.port' => $ssl_port }
-    $framework_config_url = { 'framework.server.url' => "https://${::fqdn}:${ssl_port}" }
+    $framework_config_url = { 'framework.server.url' => "http://${framework_config_base['framework.server.hostname']}:${ssl_port}" }
   }
   else {
     $framework_config_port = { 'framework.server.port' => '4440' }

--- a/manifests/config/global/framework.pp
+++ b/manifests/config/global/framework.pp
@@ -26,7 +26,7 @@ class rundeck::config::global::framework(
   }
   else {
     $framework_config_port = { 'framework.server.port' => '4440' }
-    $framework_config_url = { 'framework.server.url' => "http://${::fqdn}:4440" }
+    $framework_config_url = { 'framework.server.url' => "http://${framework_config_base['framework.server.hostname']}:4440" }
   }
 
   $properties_file = "${properties_dir}/framework.properties"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,8 @@ class rundeck::install(
   $manage_yum_repo    = $rundeck::manage_yum_repo,
   $package_ensure     = $rundeck::package_ensure,
   $package_source     = $rundeck::package_source,
-  $rdeck_home         = $rundeck::rdeck_home
+  $rdeck_home         = $rundeck::rdeck_home,
+  $manage_user        = $undeck::manage_user
 ) {
 
   if $caller_module_name != $module_name {
@@ -100,24 +101,27 @@ class rundeck::install(
     }
   }
 
-  if $user == 'rundeck' and $user_id == '' {
-    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
-  }
-  elsif $user == 'rundeck' and $user_id != '' and $group_id != '' {
-    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group], 'uid' => $user_id, 'gid' => $group_id } )
-  }
-  elsif $user != 'rundeck' and $user_id != '' and $group_id != '' {
-    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group], 'uid' => $user_id, 'gid' => $group_id } )
+  if $manage_user == true {
 
-    user { 'rundeck':
-      ensure => absent,
+    if $user == 'rundeck' and $user_id == '' {
+      ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
     }
-  }
-  else {
-    ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
+    elsif $user == 'rundeck' and $user_id != '' and $group_id != '' {
+      ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group], 'uid' => $user_id, 'gid' => $group_id } )
+    }
+    elsif $user != 'rundeck' and $user_id != '' and $group_id != '' {
+      ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group], 'uid' => $user_id, 'gid' => $group_id } )
 
-    user { 'rundeck':
-      ensure => absent,
+      user { 'rundeck':
+        ensure => absent,
+      }
+    }
+    else {
+      ensure_resource('user', $user, { 'ensure' => 'present', 'groups' => [$group] } )
+
+      user { 'rundeck':
+        ensure => absent,
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,8 @@ class rundeck::params {
   $rdeck_home = '/var/lib/rundeck'
   $service_logs_dir = '/var/log/rundeck'
 
+  $manage_user = false
+
   $framework_config = {
     'framework.server.name'     => $::fqdn,
     'framework.server.hostname' => $::fqdn,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,16 +12,18 @@ class rundeck::params {
   case $::osfamily {
     'Debian': {
       $package_name = 'rundeck'
-      $package_ensure = '2.5.1-1-GA'
       $service_name = 'rundeckd'
-      $manage_yum_repo = false
       $deb_download = true
+      $package_ensure = '2.5.1-1-GA'
+      $manage_repo = true
+      $manage_yum_repo = false
     }
     'RedHat', 'Amazon': {
       $package_name = 'rundeck'
       $package_ensure = 'installed'
       $service_name = 'rundeckd'
       $manage_yum_repo = true
+      $manage_repo = $manage_yum_repo
       $deb_download = false
     }
     default: {
@@ -37,8 +39,6 @@ class rundeck::params {
   $rdeck_base = '/var/lib/rundeck'
   $rdeck_home = '/var/lib/rundeck'
   $service_logs_dir = '/var/log/rundeck'
-
-  $manage_user = false
 
   $framework_config = {
     'framework.server.name'     => $::fqdn,
@@ -281,6 +281,8 @@ class rundeck::params {
     'attributeName' => 'REMOTE_USER_GROUPS',
     'delimiter'     => ':',
   }
+
+  $quartz_job_threadcount = 10
 
   $server_web_context = undef
   $jvm_args = '-Xmx1024m -Xms256m -server'


### PR DESCRIPTION
Issue: framewok.server.url is overwritten with fqdn fact, no matter if you set it as a parameter. This is because framework.server.url is generated using the hostname from the fact, but in some cases you don't want them to be the same (for instance when generating EC2 instances with a hostname not matching the DNS hostname for the service)

Fix:
This fix sets the framewok.server.url using the framework.server.hostname instead of the fqdn fact.