### PR TITLE
install rundeck from apt for osfamily debian

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,5 +5,6 @@ fixtures:
     archive: "https://github.com/puppet-community/puppet-archive.git"
     dirtree: "https://github.com/puppetlabs/pltraining-dirtree.git"
     java_ks: "https://github.com/puppetlabs/puppetlabs-java_ks.git"
+    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
   symlinks:
     rundeck: "#{source_dir}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -180,6 +180,7 @@ class rundeck::config(
     security_roles_array_enabled => $security_roles_array_enabled,
     security_roles_array         => $security_roles_array,
     notify                       => Service[$service_name],
+    require                      => Class['::rundeck::install'],
   }
 
   if !empty($kerberos_realms) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,6 +204,7 @@ class rundeck (
   $manage_default_admin_policy  = $rundeck::params::manage_default_admin_policy,
   $manage_default_api_policy    = $rundeck::params::manage_default_api_policy,
   $manage_yum_repo              = $rundeck::params::manage_yum_repo,
+  $manage_repo                  = $rundeck::params::manage_repo,
   $package_ensure               = $rundeck::params::package_ensure,
   $package_source               = $rundeck::params::package_source,
   $preauthenticated_config      = $rundeck::params::preauthenticated_config,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,7 @@
 class rundeck::install(
   $deb_download       = $rundeck::deb_download,
   $manage_yum_repo    = $rundeck::manage_yum_repo,
+  $manage_repo        = $rundeck::manage_repo,
   $package_ensure     = $rundeck::package_ensure,
   $package_source     = $rundeck::package_source,
   $rdeck_home         = $rundeck::rdeck_home
@@ -36,7 +37,7 @@ class rundeck::install(
 
   case $::osfamily {
     'RedHat': {
-      if $manage_yum_repo == true {
+      if ($manage_repo == true or $manage_yum_repo == true) {
         yumrepo { 'bintray-rundeck':
           baseurl  => 'http://dl.bintray.com/rundeck/rundeck-rpm/',
           descr    => 'bintray rundeck repo',
@@ -51,18 +52,44 @@ class rundeck::install(
       ensure_resource('package', 'rundeck-config', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     'Debian': {
-      include ::apt
-      apt::source { 'bintray-rundeck':
-        location => 'https://dl.bintray.com/rundeck/rundeck-deb',
-        release  => '/',
-        repos    => '',
-        key      => {
-          id     => '379CE192D401AB61',
-          server => 'keyserver.ubuntu.com',
-        },
-        before   => Package['rundeck'],
+      if $deb_download == true {
+
+        $version = inline_template("<% package_version = '${package_ensure}' %><%= package_version.split('-')[0] %>")
+
+        if $::rundeck_version != $version {
+          exec { 'download rundeck package':
+            command => "/usr/bin/wget ${package_source}/rundeck-${package_ensure}.deb -O /tmp/rundeck-${package_ensure}.deb",
+            unless  => "/usr/bin/test -f /tmp/rundeck-${package_ensure}.deb",
+          }
+
+          exec { 'stop rundeck service':
+            command => '/usr/sbin/service rundeckd stop',
+            unless  => "/bin/bash -c 'if pgrep -f RunServer > /dev/null; then echo 1; else echo 0; fi'",
+          }
+
+          exec { 'install rundeck package':
+            command => "/usr/bin/dpkg --force-confold --ignore-depends 'java7-runtime' -i /tmp/rundeck-${package_ensure}.deb",
+            unless  => "/usr/bin/dpkg -l | grep rundeck | grep ${version}",
+            require => [ Exec['download rundeck package'], Exec['stop rundeck service'] ],
+          }
+        }
       }
-      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
+      else {
+        if $manage_repo == true {
+          include ::apt
+          apt::source { 'bintray-rundeck':
+            location => 'https://dl.bintray.com/rundeck/rundeck-deb',
+            release  => '/',
+            repos    => '',
+            key      => {
+              id     => '8756C4F765C9AC3CB6B85D62379CE192D401AB61',
+              server => 'keyserver.ubuntu.com',
+            },
+            before   => Package['rundeck'],
+          }
+        }
+        ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'], require => Class[Apt::Update] } )
+      }
     }
     default: {
       err("The osfamily: ${::osfamily} is not supported")

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,28 +51,18 @@ class rundeck::install(
       ensure_resource('package', 'rundeck-config', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     'Debian': {
-      if $deb_download == true {
-
-        $version = inline_template("<% package_version = '${package_ensure}' %><%= package_version.split('-')[0] %>")
-
-        if $::rundeck_version != $version {
-          exec { 'download rundeck package':
-            command => "/usr/bin/wget ${package_source}/rundeck-${package_ensure}.deb -O /tmp/rundeck-${package_ensure}.deb",
-            unless  => "/usr/bin/test -f /tmp/rundeck-${package_ensure}.deb",
-          }
-
-          exec { 'stop rundeck service':
-            command => '/usr/sbin/service rundeckd stop',
-            unless  => "/bin/bash -c 'if pgrep -f RunServer > /dev/null; then echo 1; else echo 0; fi'",
-          }
-
-          exec { 'install rundeck package':
-            command => "/usr/bin/dpkg --force-confold --ignore-depends 'java7-runtime' -i /tmp/rundeck-${package_ensure}.deb",
-            unless  => "/usr/bin/dpkg -l | grep rundeck | grep ${version}",
-            require => [ Exec['download rundeck package'], Exec['stop rundeck service'] ],
-          }
-        }
+      include ::apt
+      apt::source { 'bintray-rundeck':
+        location => 'https://dl.bintray.com/rundeck/rundeck-deb',
+        release  => '/',
+        repos    => '',
+        key      => {
+          id     => '379CE192D401AB61',
+          server => 'keyserver.ubuntu.com',
+        },
+        before   => Package['rundeck'],
       }
+      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     default: {
       err("The osfamily: ${::osfamily} is not supported")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,16 +12,18 @@ class rundeck::params {
   case $::osfamily {
     'Debian': {
       $package_name = 'rundeck'
-      $package_ensure = 'installed'
       $service_name = 'rundeckd'
-      $manage_yum_repo = false
       $deb_download = true
+      $package_ensure = '2.5.1-1-GA'
+      $manage_repo = true
+      $manage_yum_repo = false
     }
     'RedHat', 'Amazon': {
       $package_name = 'rundeck'
       $package_ensure = 'installed'
       $service_name = 'rundeckd'
       $manage_yum_repo = true
+      $manage_repo = $manage_yum_repo
       $deb_download = false
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class rundeck::params {
   case $::osfamily {
     'Debian': {
       $package_name = 'rundeck'
-      $package_ensure = '2.5.1-1-GA'
+      $package_ensure = 'installed'
       $service_name = 'rundeckd'
       $manage_yum_repo = false
       $deb_download = true

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.2"
+      "version_requirement": ">= 2.2.0 <3.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,8 @@
       "version_requirement": ">= 1.0.3 <2.0.0"
     },
     {
-      "name": "puppetlabs/apt"
+      "name": "puppetlabs/apt",
+      "version_requirement": ">=2.2"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -65,6 +65,9 @@
     {
       "name": "puppetlabs/java_ks",
       "version_requirement": ">= 1.0.3 <2.0.0"
+    },
+    {
+      "name": "puppetlabs/apt"
     }
   ]
 }

--- a/spec/classes/config/global/aclpolicyfile_spec.rb
+++ b/spec/classes/config/global/aclpolicyfile_spec.rb
@@ -4,10 +4,13 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config::global::aclpolicyfile class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:params) { {} }
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             fqdn: 'test.domain.com',
             serialnumber: 0,
             rundeck_version: ''

--- a/spec/classes/config/global/auth_spec.rb
+++ b/spec/classes/config/global/auth_spec.rb
@@ -6,6 +6,7 @@ describe 'rundeck' do
   let(:facts) do
     {
       osfamily: 'Debian',
+      lsbdistid: 'debian',
       fqdn: 'test.domain.com',
       serialnumber: 0,
       rundeck_version: '',

--- a/spec/classes/config/global/file_keystore_spec.rb
+++ b/spec/classes/config/global/file_keystore_spec.rb
@@ -4,6 +4,7 @@ describe 'rundeck' do
   let(:facts) do
     {
       osfamily: 'Debian',
+      lsbdistid: 'debian',
       fqdn: 'test.domain.com',
       serialnumber: 0,
       rundeck_version: '',

--- a/spec/classes/config/global/framework_spec.rb
+++ b/spec/classes/config/global/framework_spec.rb
@@ -6,10 +6,13 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config::global::framework class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:params) { {} }
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             fqdn: 'test.domain.com',
             serialnumber: 0,
             rundeck_version: '',
@@ -59,6 +62,7 @@ describe 'rundeck' do
       let(:facts) do
         {
           osfamily: 'Debian',
+          lsbdistid: 'debian',
           fqdn: 'test.domain.com',
           serialnumber: 0,
           rundeck_version: '',
@@ -84,6 +88,7 @@ describe 'rundeck' do
       let(:facts) do
         {
           osfamily: 'Debian',
+          lsbdistid: 'debian',
           fqdn: 'test.domain.com',
           serialnumber: 0,
           rundeck_version: '',

--- a/spec/classes/config/global/project_spec.rb
+++ b/spec/classes/config/global/project_spec.rb
@@ -4,10 +4,13 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config::global::project class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:params) { {} }
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -4,10 +4,13 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config::global::rundeck_config class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:params) { {} }
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             fqdn: 'test.domain.com',
             serialnumber: 0,
             rundeck_version: '',

--- a/spec/classes/config/global/scm_spec.rb
+++ b/spec/classes/config/global/scm_spec.rb
@@ -4,6 +4,7 @@ describe 'rundeck' do
   let(:facts) do
     {
       osfamily: 'Debian',
+      lsbdistid: 'debian',
       fqdn: 'test.domain.com',
       serialnumber: 0,
       rundeck_version: '',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -6,9 +6,12 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: '3.8.1'

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -20,7 +20,9 @@ describe 'rundeck' do
         if osfamily.eql?('RedHat')
           it { is_expected.to contain_yumrepo('bintray-rundeck') }
         else
-          it { is_expected.to contain_apt__source('bintray-rundeck') }
+          it { is_expected.to contain_exec('download rundeck package') }
+          it { is_expected.to contain_exec('install rundeck package') }
+          it { is_expected.not_to contain_yumrepo('bintray-rundeck') }
         end
 
         it do

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -4,10 +4,12 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
         let(:params) { {} }
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: '3.8.1'
@@ -18,9 +20,7 @@ describe 'rundeck' do
         if osfamily.eql?('RedHat')
           it { is_expected.to contain_yumrepo('bintray-rundeck') }
         else
-          it { is_expected.to contain_exec('download rundeck package') }
-          it { is_expected.to contain_exec('install rundeck package') }
-          it { is_expected.not_to contain_yumrepo('bintray-rundeck') }
+          it { is_expected.to contain_apt__source('bintray-rundeck') }
         end
 
         it do
@@ -54,6 +54,7 @@ describe 'rundeck' do
     let(:facts) do
       {
         osfamily: 'Debian',
+        lsbdistid: 'debian',
         serialnumber: 0,
         rundeck_version: '',
         puppetversion: '3.8.1'
@@ -96,6 +97,7 @@ describe 'rundeck' do
     let(:facts) do
       {
         osfamily: 'Debian',
+        lsbdistid: 'debian',
         serialnumber: 0,
         rundeck_version: '',
         puppetversion: '3.8.1'

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -6,10 +6,13 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:params) { {} }
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: '3.8.1'

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -4,10 +4,13 @@ describe 'rundeck' do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck class without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:params) { {} }
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: '3.8.1'

--- a/spec/defines/config/plugin_spec.rb
+++ b/spec/defines/config/plugin_spec.rb
@@ -18,6 +18,7 @@ describe 'rundeck::config::plugin', type: :define do
         let(:facts) do
           {
             osfamily: 'Debian',
+            lsbdistid: 'debian',
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version
@@ -55,6 +56,7 @@ describe 'rundeck::config::plugin', type: :define do
         let(:facts) do
           {
             osfamily: 'Debian',
+            lsbdistid: 'debian',
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version

--- a/spec/defines/config/project_spec.rb
+++ b/spec/defines/config/project_spec.rb
@@ -4,6 +4,8 @@ describe 'rundeck::config::project', type: :define do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config::project definition without any parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         projects_dir = '/var/rundeck/projects'
 
         let(:title) { 'test' }
@@ -24,6 +26,7 @@ describe 'rundeck::config::project', type: :define do
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version

--- a/spec/defines/config/resource_source_spec.rb
+++ b/spec/defines/config/resource_source_spec.rb
@@ -4,6 +4,8 @@ describe 'rundeck::config::resource_source', type: :define do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config::resource_source definition with default parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:title) { 'source one' }
         let(:params) do
           {
@@ -21,6 +23,7 @@ describe 'rundeck::config::resource_source', type: :define do
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version
@@ -55,6 +58,8 @@ describe 'rundeck::config::resource_source', type: :define do
       end
 
       describe "rundeck::config::resource_source definition with url parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:title) { 'source one' }
         let(:params) do
           {
@@ -73,6 +78,7 @@ describe 'rundeck::config::resource_source', type: :define do
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             puppetversion: Puppet.version,
             rundeck_version: ''
@@ -98,6 +104,8 @@ describe 'rundeck::config::resource_source', type: :define do
       end
 
       describe "rundeck::config::resource definition with directory parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:title) { 'source one' }
         let(:params) do
           {
@@ -116,6 +124,7 @@ describe 'rundeck::config::resource_source', type: :define do
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version
@@ -139,6 +148,8 @@ describe 'rundeck::config::resource_source', type: :define do
       end
 
       describe "rundeck::config::resource definition with script parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:title) { 'source one' }
         let(:params) do
           {
@@ -158,6 +169,7 @@ describe 'rundeck::config::resource_source', type: :define do
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version
@@ -185,6 +197,8 @@ describe 'rundeck::config::resource_source', type: :define do
       end
 
       describe "rundeck::config::resource definition with Puppet Enterprise parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:title) { 'source one' }
         let(:params) do
           {
@@ -208,6 +222,7 @@ describe 'rundeck::config::resource_source', type: :define do
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version

--- a/spec/defines/config/securityroles_spec.rb
+++ b/spec/defines/config/securityroles_spec.rb
@@ -4,6 +4,8 @@ describe 'rundeck::config::securityroles', type: :define do
   context 'supported operating systems' do
     %w(Debian RedHat).each do |osfamily|
       describe "rundeck::config::securityroles definition with array parameters on #{osfamily}" do
+        lsbdistid = 'debian' if osfamily.eql?('Debian')
+
         let(:title) { 'source one' }
         let(:params) do
           {
@@ -13,6 +15,7 @@ describe 'rundeck::config::securityroles', type: :define do
         let(:facts) do
           {
             osfamily: osfamily,
+            lsbdistid: lsbdistid,
             serialnumber: 0,
             rundeck_version: '',
             puppetversion: Puppet.version

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,6 +23,7 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppetlabs-java'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppetlabs-inifile'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppetlabs-apt'), acceptable_exit_codes: [0, 1]
     end
   end
 end


### PR DESCRIPTION
rundeck packages are available from bintray ( https://bintray.com/rundeck/rundeck-deb )
obviously we want to use apt to install rundeck on debian-based hosts

im available on freenode#voxpupuli if you have questions

(see PR #285 , thanks to @grafjo for explaining rspec to me:-) )