### PR TITLE
Set puppet minimum version_requirement to 3.8.7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,8 @@
       "version_requirement": ">= 4.6.0 <5.0.0"
     },
     {
-      "name": "pltraining/dirtree"
+      "name": "pltraining/dirtree",
+      "version_requirement": ">= 0.3.0 <2.0.0"
     },
     {
       "name": "puppetlabs/inifile",
@@ -61,6 +62,12 @@
     {
       "name": "puppet/archive",
       "version_requirement": ">= 0.3.0 <1.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 <5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions

Also set pltraining/dirtree dependency version range