### PR TITLE
Set minimum version dependencies (for Puppet 4)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,15 +57,15 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.3.0 <2.0.0"
+      "version_requirement": ">= 1.4.1 <2.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.3.0 <2.0.0"
+      "version_requirement": ">= 1.0.0 <2.0.0"
     },
     {
       "name": "puppetlabs/java_ks",
-      "version_requirement": ">= 1.0.3 <2.0.0"
+      "version_requirement": ">= 1.3.1 <2.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
Bump dependencies to the minimum version that should work under Puppet 4, based on the metadata