### PR TITLE
added userPasswordAttribute to ldap config, like AD config

### DIFF
--- a/templates/_auth_ldap.erb
+++ b/templates/_auth_ldap.erb
@@ -26,6 +26,7 @@ provider_url =
   userBaseDn="<%= @auth_config['ldap']['user_base_dn'] %>"
   userRdnAttribute="<%= @auth_config['ldap']['user_rdn_attribute'] %>"
   userIdAttribute="<%= @auth_config['ldap']['user_id_attribute'] %>"
+  userPasswordAttribute="<%= @auth_config['ldap']['user_password_attribute'] %>" 
   userObjectClass="<%= @auth_config['ldap']['user_object_class'] %>"
   roleBaseDn="<%= @auth_config['ldap']['role_base_dn'] %>"
   roleNameAttribute="<%= @auth_config['ldap']['role_name_attribute'] %>"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
added userPasswordAttribute to ldap config template, like the ad config template( see https://github.com/voxpupuli/puppet-rundeck/blob/5e2f06e10ae5c1a576ac52b23231b3790e3179aa/templates/_auth_ad.erb#L27 ) as my ldap setup required it as well. 