### PR TITLE
Adding missing api config settings.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,6 +128,9 @@ class rundeck::params {
         'adhoc' => [
           {'allow' => ['read','run','kill']}
         ],
+        'job' => [
+          {'allow' => ['create','read','update','delete','run','kill']}
+        ],
         'node' => [
           {'allow' => ['read','run']}
         ],


### PR DESCRIPTION
 The default rundeck api acl config, has an additional section describing job acls, which are required when using rundeck from jenkins for instance.