### PR TITLE
rundeckd var missing in profile template

### DIFF
--- a/templates/profile.erb
+++ b/templates/profile.erb
@@ -52,3 +52,5 @@ unset JRE_HOME
 fi
 
 umask 002
+
+rundeckd="$JAVA_CMD $RDECK_JVM $RDECK_SSL_OPTS -cp $BOOTSTRAP_CP com.dtolabs.rundeck.RunServer $RDECK_BASE"


### PR DESCRIPTION
/etc/rc.d/init.d/rundeckd needs $rundeckd

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
