### PR TITLE
Fix ini settings for aws-ec2 resource source

### DIFF
--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -298,7 +298,7 @@ define rundeck::config::resource_source(
       }
     }
     'aws-ec2': {
-      ini_setting { "resources.source.${number}.config.mappingParams":
+      ini_setting { "${name}::resources.source.${number}.config.mappingParams":
         ensure  => present,
         path    => $properties_file,
         section => '',
@@ -306,7 +306,7 @@ define rundeck::config::resource_source(
         value   => $mapping_params,
         require => File[$properties_file],
       }
-      ini_setting { "resources.source.${number}.config.useDefaultMapping":
+      ini_setting { "${name}::resources.source.${number}.config.useDefaultMapping":
         ensure  => present,
         path    => $properties_file,
         section => '',
@@ -314,7 +314,7 @@ define rundeck::config::resource_source(
         value   => bool2str($use_default_mapping),
         require => File[$properties_file],
       }
-      ini_setting { "resources.source.${number}.config.runningOnly":
+      ini_setting { "${name}::resources.source.${number}.config.runningOnly":
         ensure  => present,
         path    => $properties_file,
         section => '',


### PR DESCRIPTION
If using multiple AWS EC2 resource sources a duplicate declaration raises following the fact there's no project notion in the resource name.
