### PR TITLE
Change to use `fqdn_uuid()` function

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,12 @@ class rundeck::params {
   $rdeck_home = '/var/lib/rundeck'
   $service_logs_dir = '/var/log/rundeck'
 
+  $rdeck_uuid = $facts['serialnumber'] ? {
+    '0'     => fqdn_uuid($::fqdn),
+    undef   => fqdn_uuid($::fqdn),
+    default => $facts['serialnumber'],
+  }
+
   $framework_config = {
     'framework.server.name'     => $::fqdn,
     'framework.server.hostname' => $::fqdn,
@@ -53,7 +59,7 @@ class rundeck::params {
     'framework.ssh.keypath'     => '/var/lib/rundeck/.ssh/id_rsa',
     'framework.ssh.user'        => 'rundeck',
     'framework.ssh.timeout'     => '0',
-    'rundeck.server.uuid'       => $::serialnumber,
+    'rundeck.server.uuid'       => $rdeck_uuid,
   }
 
   $auth_types = ['file']

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.15.0 < 5.0.0"
     },
     {
       "name": "pltraining/dirtree",

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -64,6 +64,47 @@ describe 'rundeck' do
             expect(content).not_to include('providerUrl="ldap://fakeldap:983"')
           end
         end
+
+        describe 'uuid setting' do
+          context 'when serialnumber fact present' do
+            let :facts do
+              facts.merge(fqdn: 'rundeck.example.com',
+                          serialnumber: '32142097')
+            end
+
+            it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
+            it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
+              content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
+              expect(content).to include('rundeck.server.uuid = 32142097')
+            end
+          end
+
+          context 'when serialnumber fact absent' do
+            let :facts do
+              facts.merge(fqdn: 'rundeck.example.com', # uuid is ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0
+                          serialnumber: nil)
+            end
+
+            it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
+            it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
+              content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
+              expect(content).to include('rundeck.server.uuid = ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0')
+            end
+          end
+
+          context 'when serialnumber is \'0\'' do
+            let :facts do
+              facts.merge(fqdn: 'rundeck.example.com', # uuid is ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0
+                          serialnumber: '0')
+            end
+
+            it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
+            it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
+              content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
+              expect(content).to include('rundeck.server.uuid = ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0')
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
* if `$::serialnumber` fact is empty, use a UUID generated from the FQDN of the system
* bump stdlib requirement
* Adds spec to test

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

Replaces #275