### PR TITLE
Update profile.erb

### DIFF
--- a/templates/profile.erb
+++ b/templates/profile.erb
@@ -52,3 +52,5 @@ unset JRE_HOME
 fi
 
 umask 002
+
+rundeckd="$JAVA_CMD $RDECK_JVM $RDECK_JVM_OPTS -cp $BOOTSTRAP_CP com.dtolabs.rundeck.RunServer $RDECK_BASE"


### PR DESCRIPTION
Fixed the issue "Rundeck service not starting #319" by adding the missing line mentioned in the issue report.

I've tested the fix om  CentOS 7.3 and it works like a charm :-)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
