### PR TITLE
Add the rest of the options to the security hash for the rundeck config.

### DIFF
--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -7,6 +7,71 @@ describe 'rundeck' do
         facts
       end
 
+      describe "rundeck::config::global::rundeck_config class with use hmac request tokens parameter on #{os}" do
+        value = true
+        security_hash = {
+          'useHMacRequestTokens' => value
+        }
+        let(:params) { { security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.useHMacRequestTokens = #{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with use api cookie access parameter on #{os}" do
+        value = true
+        security_hash = {
+          'apiCookieAccess' => value
+        }
+        let(:params) { { security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.apiCookieAccess\.enabled = #{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with api tokens duration parameter on #{os}" do
+        duration = '0'
+        security_hash = {
+          'apiTokensDuration' => duration
+        }
+        let(:params) { { security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.api\.tokens\.duration\.max = #{duration}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with csrf referrer filter method parameter on #{os}" do
+        value = 'NONE'
+        security_hash = {
+          'csrfRefererFilterMethod' => value
+        }
+        let(:params) { { security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.filterMethod = #{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with csrf referrer require https parameter on #{os}" do
+        value = true
+        security_hash = {
+          'csrfRefererRequireHttps' => value
+        }
+        let(:params) { { security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.requireHttps = #{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with no security parameters on #{os}" do
+        bool_value = true
+        filter_method_parameter = 'NONE'
+        duration = '0'
+        security_hash = {}
+        let(:params) { { security_config: security_hash } }
+
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.useHMacRequestTokens = #{bool_value}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.apiCookieAccess\.enabled = #{bool_value}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.api\.tokens\.duration\.max = #{duration}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.filterMethod = #{filter_method_parameter}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.allowApi = #{bool_value}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.requireHttps = #{bool_value}}) }
+      end
+
       describe "rundeck::config::global::rundeck_config class without any parameters on #{os}" do
         let(:params) { {} }
 

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -2,8 +2,24 @@ loglevel.default = "<%= @rd_loglevel %>"
 rdeck.base = "<%= @rdeck_base %>"
 rss.enabled = "<%= @rss_enabled %>"
 
+<%- if @security_config.key?('useHMacRequestTokens') -%>
 rundeck.security.useHMacRequestTokens = <%= @security_config['useHMacRequestTokens'] %>
+<%- end -%>
+<%- if @security_config.key?('apiCookieAccess') -%>
 rundeck.security.apiCookieAccess.enabled = <%= @security_config['apiCookieAccess'] %>
+<%- end -%>
+<%- if @security_config.key?('apiTokensDuration') -%>
+rundeck.api.tokens.duration.max = <%= @security_config['apiTokensDuration'] %>
+<%- end -%>
+<%- if @security_config.key?('csrfRefererFilterMethod') -%>
+rundeck.security.csrf.referer.filterMethod = <%= @security_config['csrfRefererFilterMethod'] %>
+<%- end -%>
+<%- if @security_config.key?('csrfRefererAllowApi') -%>
+rundeck.security.csrf.referer.allowApi = <%= @security_config['csrfRefererAllowApi'] %>
+<%- end -%>
+<%- if @security_config.key?('csrfRefererRequireHttps') -%>
+rundeck.security.csrf.referer.requireHttps = <%= @security_config['csrfRefererRequireHttps'] %>
+<%- end -%>
 
 dataSource {
   dbCreate = "<%= @database_config['dbCreate'] %>"


### PR DESCRIPTION
Currently the template for the rundeck config accepts params for the following:

`rundeck.security.useHMacRequestTokens`
`rundeck.security.apiCookieAccess.enabled`

Added the rest of the options to the security hash for the rundeck config.  

Added to support the following:

`rundeck.api.tokens.duration.max`
`rundeck.security.csrf.referer.filterMethod`
`rundeck.security.csrf.referer.allowApi`
`rundeck.security.csrf.referer.requireHttps`

Updated tests to cover the conditionals in the template.
