### PR TITLE
Update for use with puppet5

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,7 +63,7 @@ class rundeck::install(
           before   => Package['rundeck'],
         }
       }
-      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'], require => Class[Apt::Update] } )
+      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'], require => Class['apt::update'] } )
     }
     default: {
       err("The osfamily: ${::osfamily} is not supported")

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -23,6 +23,8 @@ describe 'rundeck' do
           it { is_expected.to contain_yumrepo('bintray-rundeck') }
         when 'Debian'
           it { is_expected.to contain_apt__source('bintray-rundeck').with_location('https://dl.bintray.com/rundeck/rundeck-deb') }
+          it { is_expected.to contain_package('rundeck').that_notifies('Class[rundeck::service]') }
+          it { is_expected.to contain_package('rundeck').that_requires('Class[apt::update]') }
         end
       end
       describe 'different user and group' do


### PR DESCRIPTION
`Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Illegal Class name in class reference. A TypeReference['Apt::Update']-Type cannot be used where a String is expected at /etc/puppetlabs/code/environments/mgmt/modules/rundeck/manifests/install.pp:66:129`

The current code, breaks on  Puppet5, this pull request remedies the error above
