### PR TITLE
make jetty authfile compatible with rundeck version <2.7

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -74,6 +74,9 @@ class rundeck::config(
   $projects_dir   = $framework_config['framework.projects.dir']
   $properties_dir = $framework_config['framework.etc.dir']
 
+  # Check for jetty auth template
+  $rundeck_before_27 = versioncmp($::rundeck_version, '2.7') < 0
+
   #
   # Checking if we need to deploy realm file
   #  ugly, I know. Fix it if you know better way to do that

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -12,3 +12,4 @@ concat_basedir: "/tmp"
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+rundeck_version: "2.7"

--- a/templates/_auth_file.erb
+++ b/templates/_auth_file.erb
@@ -1,3 +1,3 @@
-org.eclipse.jetty.jaas.spi.PropertyFileLoginModule sufficient
+<% if @rundeck_before_27 %>org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule sufficient<% else %>org.eclipse.jetty.jaas.spi.PropertyFileLoginModule sufficient<% end %>
   debug="true"
   file="<%= @auth_config['file']['file'] %>";


### PR DESCRIPTION
the authfile issue in #325 has been fixed in  571e90449ba0db72f2003e728823ce88035224a2

the commit will fix the format for rundeck 2.7 and newer and break the jaas-auth.conf for rundeck 2.6 and earlier. 

this PR should allow both and respect the version in the _auth_file template
