### PR TITLE
Fix acceptance tests and run in Travis. Resolve idempotency issue

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,9 @@
 ---
 .travis.yml:
   secure: "ExSbFQsxOlpFTc/4TTGJElIx0/sYNZ1I2Nbd9EfGPNeECXBgmqTdJmPqdV6cl3mKDFh+tSSxnIDZe5BILhmxIR7aF2lbf8jwcbo2nxe9qAZ42GDKNV2klNXUjR7kA7tz220RNO9rM3HDKAwrKtCPtwQ0Q5u90YGGJDj2nr7NUaM="
+  docker_sets:
+    - set: docker/ubuntu-16.04
+    - set: docker/centos-7
   addons:
     apt:
       packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,18 @@ script:
 matrix:
   fast_finish: true
   include:
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 CHECK=beaker
+    services: docker
+    sudo: required
   - rvm: 2.1.9
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=test

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :system_tests do
   end
   gem 'serverspec',                    :require => false
   gem 'beaker-puppet_install_helper',  :require => false
+  gem 'beaker-module_install_helper',  :require => false
 end
 
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ enable `key` and `project` storage in the database, you must also set the two
 parameters associated parameters.
 
 ```puppet
-class { '::rundeck':
+class { 'rundeck':
   key_storage_type      => 'db',
   projects_storage_type => 'db',
   database_config       => {

--- a/README.md
+++ b/README.md
@@ -29,9 +29,18 @@ The rundeck puppet module for installing and managing [Rundeck](http://rundeck.o
 ## Module Description
 
 This module provides a way to manage the installation and configuration of
-rundeck, it's projects, jobs and plugins.
+rundeck, its projects, jobs and plugins.
 
 ## Setup
+
+###  Setup requirements
+
+You need a compatible version of Java installed; you can use the
+[puppetlabs/java](https://github.com/puppetlabs/puppetlabs-java) module if there
+isn't already a suitable version.
+
+On systems that use apt, there's a soft dependency on the
+[puppetlabs/apt](https://github.com/puppetlabs/puppetlabs-apt) module.
 
 ### Classes and Defined Types
 

--- a/examples/ldap_shared.pp
+++ b/examples/ldap_shared.pp
@@ -2,7 +2,7 @@
 # Configuring shared authentication credentials
 # Performs LDAP authentication and file authorization
 #
-class { '::rundeck':
+class { 'rundeck':
   auth_types  => ['ldap_shared'],
   auth_config => {
     'file' =>  {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -162,31 +162,31 @@ class rundeck::config(
     notify  => Service[$service_name],
   }
 
-  include '::rundeck::config::global::framework'
-  include '::rundeck::config::global::project'
-  include '::rundeck::config::global::rundeck_config'
-  include '::rundeck::config::global::file_keystore'
+  contain rundeck::config::global::framework
+  contain rundeck::config::global::project
+  contain rundeck::config::global::rundeck_config
+  contain rundeck::config::global::file_keystore
 
-  Class[rundeck::config::global::framework]
-  -> Class[rundeck::config::global::project]
-  -> Class[rundeck::config::global::rundeck_config]
-  -> Class[rundeck::config::global::file_keystore]
+  Class['rundeck::config::global::framework']
+  -> Class['rundeck::config::global::project']
+  -> Class['rundeck::config::global::rundeck_config']
+  -> Class['rundeck::config::global::file_keystore']
 
   if $ssl_enabled {
-    include '::rundeck::config::global::ssl'
-    Class[rundeck::config::global::rundeck_config]
-    -> Class[rundeck::config::global::ssl]
+    contain rundeck::config::global::ssl
+    Class['rundeck::config::global::rundeck_config']
+    -> Class['rundeck::config::global::ssl']
   }
 
   create_resources(rundeck::config::project, $projects)
 
-  class { '::rundeck::config::global::web':
+  class { 'rundeck::config::global::web':
     security_role                => $security_role,
     session_timeout              => $session_timeout,
     security_roles_array_enabled => $security_roles_array_enabled,
     security_roles_array         => $security_roles_array,
     notify                       => Service[$service_name],
-    require                      => Class['::rundeck::install'],
+    require                      => Class['rundeck::install'],
   }
 
   if !empty($kerberos_realms) {

--- a/manifests/config/plugin.pp
+++ b/manifests/config/plugin.pp
@@ -28,8 +28,8 @@ define rundeck::config::plugin(
   $ensure   = 'present',
 ) {
 
-  include '::rundeck'
-  include '::archive'
+  include rundeck
+  include archive
 
   $framework_config = deep_merge($::rundeck::params::framework_config, $::rundeck::framework_config)
 

--- a/manifests/config/project.pp
+++ b/manifests/config/project.pp
@@ -61,7 +61,7 @@ define rundeck::config::project (
   $user                   = $rundeck::user,
 ) {
 
-  include ::rundeck
+  include rundeck
 
   $framework_properties = deep_merge($rundeck::params::framework_config, $rundeck::framework_config, $framework_config)
 

--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -87,7 +87,7 @@ define rundeck::config::resource_source(
   $puppet_enterprise_metrics_interval = '',
 ) {
 
-  include ::rundeck
+  include rundeck
 
   $framework_properties = deep_merge($rundeck::params::framework_config, $::rundeck::framework_config)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -284,8 +284,12 @@ class rundeck (
   validate_string($user_id)
   validate_string($group_id)
 
-  class { '::rundeck::install': }
-  -> class { '::rundeck::config': }
-  ~> class { '::rundeck::service': }
-  -> Class['rundeck']
+  contain rundeck::install
+  contain rundeck::config
+  contain rundeck::service
+
+  Class['rundeck::install']
+  -> Class['rundeck::config']
+  ~> Class['rundeck::service']
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,7 +50,7 @@ class rundeck::install(
     }
     'Debian': {
       if $manage_repo == true {
-        include ::apt
+        include apt
         apt::source { 'bintray-rundeck':
           location => 'https://dl.bintray.com/rundeck/rundeck-deb',
           release  => '/',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,8 +46,7 @@ class rundeck::install(
         }
       }
 
-      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
-      ensure_resource('package', 'rundeck-config', {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
+      ensure_packages(['rundeck', 'rundeck-config'], {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     'Debian': {
       if $manage_repo == true {
@@ -63,7 +62,7 @@ class rundeck::install(
           before   => Package['rundeck'],
         }
       }
-      ensure_resource('package', 'rundeck', {'ensure' => $package_ensure, notify => Class['rundeck::service'], require => Class['apt::update'] } )
+      ensure_packages(['rundeck'], {'ensure' => $package_ensure, notify => Class['rundeck::service'], require => Class['apt::update'] } )
     }
     default: {
       err("The osfamily: ${::osfamily} is not supported")
@@ -123,6 +122,8 @@ class rundeck::install(
       mode    => '0600',
     }
   }
+
+  Package['rundeck'] -> File[$rundeck::service_logs_dir]
 
   file { $rundeck::service_logs_dir:
     ensure  => directory,

--- a/metadata.json
+++ b/metadata.json
@@ -66,10 +66,6 @@
     {
       "name": "puppetlabs/java_ks",
       "version_requirement": ">= 1.3.1 < 2.0.0"
-    },
-    {
-      "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.0 < 4.1.0"
     }
   ],
   "requirements": [

--- a/spec/acceptance/rundeck_spec.rb
+++ b/spec/acceptance/rundeck_spec.rb
@@ -1,47 +1,20 @@
-# rubocop:disable RSpec/MultipleExpectations
-
 require 'spec_helper_acceptance'
 
 describe 'rundeck class' do
-  context 'default parameters on ubuntu', if: fact('osfamily').eql?('Debian') do
-    it 'works with no errors' do
+  context 'default parameters' do
+    it 'applies successfully' do
       pp = <<-EOS
       class { 'java':
         distribution => 'jre'
       }
       class { 'rundeck': }
 
-      Package['openjdk-7-jre-headless'] -> Exec['install rundeck package']
+      Class['java'] -> Class['rundeck']
       EOS
 
       # Run it twice and test for idempotency
-      expect(apply_manifest(pp, expect_changes: true).exit_code).to eq(2)
-      expect(apply_manifest(pp).exit_code).to eq(0)
-    end
-
-    describe package('rundeck') do
-      it { is_expected.to be_installed }
-    end
-
-    describe service('rundeckd') do
-      it { is_expected.to be_running }
-    end
-  end
-
-  context 'default parameters on centos', if: fact('osfamily').eql?('RedHat') do
-    it 'works with no errors' do
-      pp = <<-EOS
-      class { 'java':
-        distribution => 'jre'
-      }
-      class { 'rundeck': }
-
-      Package['java-1.7.0-openjdk'] -> Package['rundeck']
-      EOS
-
-      # Run it twice and test for idempotency
-      expect(apply_manifest(pp).exit_code).not_to eq(1)
-      expect(apply_manifest(pp).exit_code).to eq(0)
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
 
     describe package('rundeck') do

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -1,5 +1,4 @@
 # rubocop:disable RSpec/MultipleExpectations
-
 require 'spec_helper'
 
 describe 'rundeck' do
@@ -15,9 +14,8 @@ describe 'rundeck' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('rundeck::params') }
         it { is_expected.to contain_class('rundeck::install').that_comes_before('Class[rundeck::config]') }
-        it { is_expected.to contain_class('rundeck::config') }
-        it { is_expected.to contain_class('rundeck::service').that_comes_before('Class[rundeck]') }
-        it { is_expected.to contain_class('rundeck').that_requires('Class[rundeck::service]') }
+        it { is_expected.to contain_class('rundeck::config').that_notifies('Class[rundeck::service]') }
+        it { is_expected.to contain_class('rundeck::service') }
       end
 
       context 'non-platform-specific config parameters' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,29 +1,17 @@
-require 'beaker-rspec/spec_helper'
-require 'beaker-rspec/helpers/serverspec'
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
-hosts.each do |_host|
-  version = ENV['PUPPET_GEM_VERSION']
-  install_puppet(version: version)
-end
+UNSUPPORTED_PLATFORMS = [].freeze
+
+run_puppet_install_helper
+install_module
+install_module_dependencies
+
+# Install additional modules for soft deps
+install_module_from_forge('puppetlabs-java', '>= 2.1.0 < 3.0.0')
+install_module_from_forge('puppetlabs-apt', '>= 4.1.0 < 5.0.0')
 
 RSpec.configure do |c|
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   c.formatter = :documentation
-
-  c.before :suite do
-    hosts.each do |host|
-      c.host = host
-
-      path = File.expand_path(File.dirname(__FILE__) + '/../').split('/')
-      name = path[path.length - 1].split('-')[1]
-
-      copy_module_to(host, source: proj_root, module_name: name)
-
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'puppetlabs-java'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'puppetlabs-inifile'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'puppetlabs-apt'), acceptable_exit_codes: [0, 1]
-    end
-  end
 end


### PR DESCRIPTION
This will add the acceptance tests back to the Travis matrix, simplifies them, and also resolves an idempotency issue on certain platforms.

I believe this will also fix the issue that was causing modulesync to fail.

I switched apt to be a soft dep per https://docs.puppet.com/puppet/5.1/style_guide.html#dependencies and also listed Java as a dependency (the acceptance tests install puppetlabs/java but I don't think the setup requirements mentioned it).