### PR TITLE
Drop support for RedHat 5 and Ubuntu 12, Update README and metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@
 
 The rundeck puppet module for installing and managing [Rundeck](http://rundeck.org/)
 
-[![Build Status](https://travis-ci.org/voxpupuli/puppet-rundeck.svg?branch=master)](https://travis-ci.org/voxpupuli/puppet-rundeck)
-
 ## Module Description
 
 This module provides a way to manage the installation and configuration of
@@ -445,11 +443,10 @@ class { 'rundeck':
 
 This module is tested on the following platforms:
 
-* CentOS 5
 * CentOS 6
 * CentOS 7
-* Ubuntu 12.04
 * Ubuntu 14.04
+* Ubuntu 16.04
 
 It is tested with the OSS version of Puppet only.
 

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5.0",
         "6.0",
         "7.0"
       ]
@@ -24,7 +23,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5.0",
         "6.0",
         "7.0"
       ]
@@ -40,7 +38,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
         "14.04",
         "16.04"
       ]
@@ -71,7 +68,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.1 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
Not sure if we consider dropping official support breaking (since it should still work).
@bastelfreak what do you think about pulling this in before release?