### PR TITLE
Add support to customize log4j.properties file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,7 @@ class rundeck::config(
   $key_storage_type             = $rundeck::key_storage_type,
   $keystore                     = $rundeck::keystore,
   $keystore_password            = $rundeck::keystore_password,
+  $log_properties_template      = $rundeck::log_properties_template,
   $mail_config                  = $rundeck::mail_config,
   $manage_default_admin_policy  = $rundeck::manage_default_admin_policy,
   $manage_default_api_policy    = $rundeck::manage_default_api_policy,
@@ -124,7 +125,7 @@ class rundeck::config(
   }
 
   file { "${properties_dir}/log4j.properties":
-    content => template('rundeck/log4j.properties.erb'),
+    content => template($log_properties_template),
     notify  => Service[$service_name],
     require => File[$properties_dir],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,6 +199,7 @@ class rundeck (
   $key_storage_type             = $rundeck::params::key_storage_type,
   $keystore                     = $rundeck::params::keystore,
   $keystore_password            = $rundeck::params::keystore_password,
+  $log_properties_template      = $rundeck::params::log_properties_template,
   $mail_config                  = $rundeck::params::mail_config,
   $sshkey_manage                = $rundeck::params::sshkey_manage,
   $ssl_keyfile                  = $rundeck::params::ssl_keyfile,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,6 +64,8 @@ class rundeck::params {
   $auth_users = {}
   $auth_template = 'rundeck/jaas-auth.conf.erb'
 
+  $log_properties_template = 'rundeck/log4j.properties.erb'
+
   $acl_template = 'rundeck/aclpolicy.erb'
   $api_template = 'rundeck/aclpolicy.erb'
 


### PR DESCRIPTION
Allow users to use their custom templates for generating the log4j.properties file
