### PR TITLE
Breaking: Switch to Puppet Data Types, switch to integers

### DIFF
--- a/manifests/config/aclpolicyfile.pp
+++ b/manifests/config/aclpolicyfile.pp
@@ -63,14 +63,12 @@
 # }
 #
 define rundeck::config::aclpolicyfile(
-  $acl_policies,
-  $group          = 'rundeck',
-  $owner          = 'rundeck',
-  $properties_dir = '/etc/rundeck',
-  $template_file  = "${module_name}/aclpolicy.erb",
+  Array $acl_policies,
+  String $group                        = 'rundeck',
+  String $owner                        = 'rundeck',
+  Stdlib::Absolutepath $properties_dir = '/etc/rundeck',
+  String $template_file                = "${module_name}/aclpolicy.erb",
 ) {
-
-  validate_array($acl_policies)
 
   file { "${properties_dir}/${name}.aclpolicy":
     owner   => $owner,

--- a/manifests/config/file_keystore.pp
+++ b/manifests/config/file_keystore.pp
@@ -44,23 +44,21 @@
 #   The actual value (password) of the named key
 #
 define rundeck::config::file_keystore (
-  $content_type,
-  $data_type,
+  Enum['application/x-rundeck-data-password', 'application/pgp-keys', 'application/octet-stream'] $content_type,
+  Enum['password', 'public', 'private'] $data_type,
   $path,
   $value,
-  $auth_created_username  = $::rundeck::framework_config['framework.ssh.user'],
-  $auth_modified_username = $::rundeck::framework_config['framework.ssh.user'],
-  $content_creation_time  = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
-  $content_mask           = 'content',
-  $content_modify_time    = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
-  $content_size           = undef,
-  $file_keystorage_dir    = $::rundeck::file_keystorage_dir,
-  $group                  = $::rundeck::config::group,
-  $user                   = $::rundeck::config::user,
+  $auth_created_username          = $rundeck::framework_config['framework.ssh.user'],
+  $auth_modified_username         = $rundeck::framework_config['framework.ssh.user'],
+  $content_creation_time          = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
+  String $content_mask            = 'content',
+  $content_modify_time            = chomp(generate('/bin/date', '+%Y-%m-%dT%H:%M:%SZ')),
+  Optional[Integer] $content_size = undef,
+  $file_keystorage_dir            = $rundeck::file_keystorage_dir,
+  $group                          = $rundeck::config::group,
+  $user                           = $rundeck::config::user,
 ) {
 
-  validate_re($data_type, [ 'password', 'public', 'private' ])
-  validate_re($content_type, [ 'application/x-rundeck-data-password', 'application/pgp-keys', 'application/octet-stream' ])
   ensure_resource('file', [ $file_keystorage_dir ], { 'ensure' => 'directory' })
 
   if !$content_size {

--- a/manifests/config/plugin.pp
+++ b/manifests/config/plugin.pp
@@ -24,8 +24,8 @@
 # }
 #
 define rundeck::config::plugin(
-  $source,
-  $ensure   = 'present',
+  String $source,
+  Enum['present', 'absent'] $ensure = 'present',
 ) {
 
   include rundeck
@@ -36,12 +36,6 @@ define rundeck::config::plugin(
   $user = $rundeck::user
   $group = $rundeck::group
   $plugin_dir = $framework_config['framework.libext.dir']
-
-  validate_string($source)
-  validate_absolute_path($plugin_dir)
-  validate_re($user, '[a-zA-Z0-9]{3,}')
-  validate_re($group, '[a-zA-Z0-9]{3,}')
-  validate_re($ensure, ['^present$', '^absent$'])
 
   if $ensure == 'present' {
 

--- a/manifests/config/project.pp
+++ b/manifests/config/project.pp
@@ -48,17 +48,17 @@
 # }
 #
 define rundeck::config::project (
-  String $file_copier_provider = $rundeck::file_copier_provider,
-  $framework_config            = $rundeck::framework_config,
-  $group                       = $rundeck::group,
-  $node_executor_provider      = $rundeck::node_executor_provider,
-  $node_executor_settings      = {},
-  $projects_dir                = undef,
-  $resource_sources            = $rundeck::resource_sources,
-  $scm_import_properties       = {},
-  $scm_export_properties       = {},
-  $ssh_keypath                 = undef,
-  $user                        = $rundeck::user,
+  String $file_copier_provider                 = $rundeck::file_copier_provider,
+  Hash $framework_config                       = $rundeck::framework_config,
+  String $group                                = $rundeck::group,
+  String $node_executor_provider               = $rundeck::node_executor_provider,
+  Hash $node_executor_settings                 = {},
+  Optional[Stdlib::Absolutepath] $projects_dir = undef,
+  Hash $resource_sources                       = $rundeck::resource_sources,
+  Hash $scm_import_properties                  = {},
+  Hash $scm_export_properties                  = {},
+  Optional[Stdlib::Absolutepath] $ssh_keypath  = undef,
+  String $user                                 = $rundeck::user,
 ) {
 
   include rundeck
@@ -74,13 +74,6 @@ define rundeck::config::project (
     undef   => $framework_properties['framework.projects.dir'],
     default => $projects_dir,
   }
-
-  validate_absolute_path($_ssh_keypath)
-  validate_hash($resource_sources)
-  validate_hash($scm_import_properties)
-  validate_absolute_path($_projects_dir)
-  validate_re($user, '[a-zA-Z0-9]{3,}')
-  validate_re($group, '[a-zA-Z0-9]{3,}')
 
   $project_dir = "${_projects_dir}/${name}"
   $properties_file = "${project_dir}/etc/project.properties"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,113 +177,73 @@
 #  $security_roles_array         = hiera('rundeck::config::global::web::security_roles_array', []),
 #
 class rundeck (
-  $acl_policies                 = $rundeck::params::acl_policies,
-  $acl_template                 = $rundeck::params::acl_template,
-  $api_policies                 = $rundeck::params::api_policies,
-  $api_template                 = $rundeck::params::api_template,
-  $auth_config                  = $rundeck::params::auth_config,
-  $auth_template                = $rundeck::params::auth_template,
-  $auth_types                   = $rundeck::params::auth_types,
-  $clustermode_enabled          = $rundeck::params::clustermode_enabled,
-  $database_config              = $rundeck::params::database_config,
-  $file_keystorage_dir          = $rundeck::params::file_keystorage_dir,
-  $file_keystorage_keys         = $rundeck::params::file_keystorage_keys,
-  $framework_config             = $rundeck::params::framework_config,
-  $grails_server_url            = $rundeck::params::grails_server_url,
-  $group                        = $rundeck::params::group,
-  $gui_config                   = $rundeck::params::gui_config,
-  $java_home                    = $rundeck::params::java_home,
-  $jvm_args                     = $rundeck::params::jvm_args,
-  $kerberos_realms              = $rundeck::params::kerberos_realms,
-  $key_password                 = $rundeck::params::key_password,
-  $key_storage_type             = $rundeck::params::key_storage_type,
-  $keystore                     = $rundeck::params::keystore,
-  $keystore_password            = $rundeck::params::keystore_password,
-  $log_properties_template      = $rundeck::params::log_properties_template,
-  $mail_config                  = $rundeck::params::mail_config,
-  $sshkey_manage                = $rundeck::params::sshkey_manage,
-  $ssl_keyfile                  = $rundeck::params::ssl_keyfile,
-  $ssl_certfile                 = $rundeck::params::ssl_certfile,
-  $manage_default_admin_policy  = $rundeck::params::manage_default_admin_policy,
-  $manage_default_api_policy    = $rundeck::params::manage_default_api_policy,
-  $manage_repo                  = $rundeck::params::manage_repo,
-  $package_ensure               = $rundeck::params::package_ensure,
-  $package_source               = $rundeck::params::package_source,
-  $preauthenticated_config      = $rundeck::params::preauthenticated_config,
-  $projects                     = $rundeck::params::projects,
-  $projects_description         = $rundeck::params::projects_default_desc,
-  $projects_organization        = $rundeck::params::projects_default_org,
-  $projects_storage_type        = $rundeck::params::projects_storage_type,
-  $quartz_job_threadcount       = $rundeck::params::quartz_job_threadcount,
-  $rd_loglevel                  = $rundeck::params::loglevel,
-  $rd_auditlevel                = $rundeck::params::loglevel,
-  $rdeck_config_template        = $rundeck::params::rdeck_config_template,
-  $rdeck_home                   = $rundeck::params::rdeck_home,
-  $rdeck_profile_template       = $rundeck::params::rdeck_profile_template,
-  $realm_template               = $rundeck::params::realm_template,
-  $rss_enabled                  = $rundeck::params::rss_enabled,
-  $security_config              = $rundeck::params::security_config,
-  $security_role                = $rundeck::params::security_role,
-  $server_web_context           = $rundeck::params::server_web_context,
-  $service_config               = $rundeck::params::service_config,
-  $service_logs_dir             = $rundeck::params::service_logs_dir,
-  $service_manage               = $rundeck::params::service_manage,
-  $service_name                 = $rundeck::params::service_name,
-  $service_script               = $rundeck::params::service_script,
-  $service_ensure               = $rundeck::params::service_ensure,
-  $session_timeout              = $rundeck::params::session_timeout,
-  $ssl_enabled                  = $rundeck::params::ssl_enabled,
-  $ssl_port                     = $rundeck::params::ssl_port,
-  $truststore                   = $rundeck::params::truststore,
-  $truststore_password          = $rundeck::params::truststore_password,
-  $user                         = $rundeck::params::user,
-  $user_id                      = $rundeck::params::user_id,
-  $group_id                     = $rundeck::params::group_id,
-  $security_roles_array_enabled = $rundeck::params::security_roles_array_enabled,
-  $security_roles_array         = $rundeck::params::security_roles_array,
+  $acl_policies                                   = $rundeck::params::acl_policies,
+  $acl_template                                   = $rundeck::params::acl_template,
+  $api_policies                                   = $rundeck::params::api_policies,
+  $api_template                                   = $rundeck::params::api_template,
+  Hash $auth_config                               = $rundeck::params::auth_config,
+  $auth_template                                  = $rundeck::params::auth_template,
+  Array $auth_types                               = $rundeck::params::auth_types,
+  Boolean $clustermode_enabled                    = $rundeck::params::clustermode_enabled,
+  Hash $database_config                           = $rundeck::params::database_config,
+  Stdlib::Absolutepath $file_keystorage_dir       = $rundeck::params::file_keystorage_dir,
+  Hash $file_keystorage_keys                      = $rundeck::params::file_keystorage_keys,
+  Hash $framework_config                          = $rundeck::params::framework_config,
+  Stdlib::HTTPUrl $grails_server_url              = $rundeck::params::grails_server_url,
+  String $group                                   = $rundeck::params::group,
+  Hash $gui_config                                = $rundeck::params::gui_config,
+  Optional[Stdlib::Absolutepath] $java_home       = undef,
+  $jvm_args                                       = $rundeck::params::jvm_args,
+  Hash $kerberos_realms                           = $rundeck::params::kerberos_realms,
+  $key_password                                   = $rundeck::params::key_password,
+  Enum['db', 'file'] $key_storage_type            = $rundeck::params::key_storage_type,
+  Stdlib::Absolutepath $keystore                  = $rundeck::params::keystore,
+  String $keystore_password                       = $rundeck::params::keystore_password,
+  $log_properties_template                        = $rundeck::params::log_properties_template,
+  Hash $mail_config                               = $rundeck::params::mail_config,
+  Boolean $sshkey_manage                          = $rundeck::params::sshkey_manage,
+  Stdlib::Absolutepath $ssl_keyfile               = $rundeck::params::ssl_keyfile,
+  Stdlib::Absolutepath $ssl_certfile              = $rundeck::params::ssl_certfile,
+  Boolean $manage_default_admin_policy            = $rundeck::params::manage_default_admin_policy,
+  Boolean $manage_default_api_policy              = $rundeck::params::manage_default_api_policy,
+  Boolean $manage_repo                            = $rundeck::params::manage_repo,
+  String $package_ensure                          = $rundeck::params::package_ensure,
+  Stdlib::HTTPUrl $package_source                 = $rundeck::params::package_source,
+  Hash $preauthenticated_config                   = $rundeck::params::preauthenticated_config,
+  Hash $projects                                  = $rundeck::params::projects,
+  String $projects_description                    = $rundeck::params::projects_default_desc,
+  String $projects_organization                   = $rundeck::params::projects_default_org,
+  Enum['db', 'filesystem'] $projects_storage_type = $rundeck::params::projects_storage_type,
+  Integer $quartz_job_threadcount                 = $rundeck::params::quartz_job_threadcount,
+  Rundeck::Loglevel $rd_loglevel                  = $rundeck::params::loglevel,
+  Rundeck::Loglevel $rd_auditlevel                = $rundeck::params::loglevel,
+  $rdeck_config_template                          = $rundeck::params::rdeck_config_template,
+  Stdlib::Absolutepath $rdeck_home                = $rundeck::params::rdeck_home,
+  Optional[String] $rdeck_profile_template        = undef,
+  $realm_template                                 = $rundeck::params::realm_template,
+  Boolean $rss_enabled                            = $rundeck::params::rss_enabled,
+  $security_config                                = $rundeck::params::security_config,
+  $security_role                                  = $rundeck::params::security_role,
+  Optional[String] $server_web_context            = undef,
+  $service_config                                 = $rundeck::params::service_config,
+  Stdlib::Absolutepath $service_logs_dir          = $rundeck::params::service_logs_dir,
+  $service_manage                                 = $rundeck::params::service_manage,
+  String $service_name                            = $rundeck::params::service_name,
+  String $service_script                          = $rundeck::params::service_script,
+  String $service_ensure                          = $rundeck::params::service_ensure,
+  Integer $session_timeout                        = $rundeck::params::session_timeout,
+  Boolean $ssl_enabled                            = $rundeck::params::ssl_enabled,
+  Integer $ssl_port                               = $rundeck::params::ssl_port,
+  Stdlib::Absolutepath $truststore                = $rundeck::params::truststore,
+  String $truststore_password                     = $rundeck::params::truststore_password,
+  String $user                                    = $rundeck::params::user,
+  Optional[Integer] $user_id                      = undef,
+  Optional[Integer] $group_id                     = undef,
+  Boolean $security_roles_array_enabled           = $rundeck::params::security_roles_array_enabled,
+  Array $security_roles_array                     = $rundeck::params::security_roles_array,
 ) inherits rundeck::params {
 
-  validate_array($auth_types)
-  validate_hash($auth_config)
-  validate_bool($sshkey_manage)
-  validate_bool($ssl_enabled)
-  validate_hash($projects)
-  validate_string($projects_organization)
-  validate_string($projects_description)
-  validate_re($rd_loglevel, [ '^ALL$', '^DEBUG$', '^ERROR$', '^FATAL$', '^INFO$', '^OFF$', '^TRACE$', '^WARN$' ])
-  validate_re($rd_auditlevel, [ '^ALL$', '^DEBUG$', '^ERROR$', '^FATAL$', '^INFO$', '^OFF$', '^TRACE$', '^WARN$' ])
-  validate_re($projects_storage_type, [ '^db$', '^filesystem$' ])
-  validate_bool($rss_enabled)
-  validate_bool($clustermode_enabled)
-  validate_string($grails_server_url)
-  validate_hash($gui_config)
-  validate_hash($database_config)
-  validate_hash($kerberos_realms)
-  validate_absolute_path($keystore)
-  validate_absolute_path($ssl_certfile)
-  validate_absolute_path($ssl_keyfile)
-  validate_re($key_storage_type, [ '^db$', '^file$' ])
-  validate_string($keystore_password)
-  validate_string($key_password)
-  validate_absolute_path($truststore)
-  validate_string($truststore_password)
-  validate_string($service_name)
-  validate_string($package_ensure)
-  validate_hash($mail_config)
-  validate_hash($preauthenticated_config)
-  validate_integer($quartz_job_threadcount)
-  validate_string($user)
-  validate_string($group)
-  validate_string($server_web_context)
-  validate_absolute_path($rdeck_home)
   validate_rd_policy($acl_policies)
-  validate_hash($file_keystorage_keys)
-  validate_bool($manage_default_admin_policy)
-  validate_bool($manage_default_api_policy)
-  validate_bool($security_roles_array_enabled)
-  validate_array($security_roles_array)
-  validate_string($user_id)
-  validate_string($group_id)
 
   contain rundeck::install
   contain rundeck::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -235,7 +235,7 @@ class rundeck::params {
   $node_executor_provider = 'jsch-ssh'
 
   $url_cache = true
-  $url_timeout = '30'
+  $url_timeout = 30
 
   $resource_format = 'resourcexml'
   $include_server_node = false
@@ -247,8 +247,6 @@ class rundeck::params {
 
   $user = 'rundeck'
   $group = 'rundeck'
-  $user_id = ''
-  $group_id = ''
 
   $loglevel = 'INFO'
   $rss_enabled = false
@@ -289,15 +287,12 @@ class rundeck::params {
 
   $quartz_job_threadcount = 10
 
-  $server_web_context = undef
   $jvm_args = '-Xmx1024m -Xms256m -server'
-
-  $java_home = undef
 
   $sshkey_manage = true
 
   $ssl_enabled = false
-  $ssl_port = '4443'
+  $ssl_port = 4443
 
   $ssl_keyfile = '/etc/rundeck/ssl/rundeck.key'
   $ssl_certfile = '/etc/rundeck/ssl/rundeck.crt'
@@ -309,7 +304,6 @@ class rundeck::params {
   $session_timeout = 30
 
   $rdeck_config_template = 'rundeck/rundeck-config.erb'
-  $rdeck_profile_template = undef
 
   $file_keystorage_keys = { }
   $file_keystorage_dir = "${framework_config['framework.var.dir']}/storage"

--- a/spec/classes/config/global/framework_spec.rb
+++ b/spec/classes/config/global/framework_spec.rb
@@ -62,7 +62,7 @@ describe 'rundeck' do
           let(:params) do
             {
               ssl_enabled: true,
-              ssl_port: '443'
+              ssl_port: 443
             }
           end
 

--- a/spec/classes/config/global/web_spec.rb
+++ b/spec/classes/config/global/web_spec.rb
@@ -27,7 +27,7 @@ describe 'rundeck' do
   end
 
   context 'with session_timeout param' do
-    let(:params) { { session_timeout: '60' } }
+    let(:params) { { session_timeout: 60 } }
 
     it 'generates augeas resource with specified session_timeout' do
       is_expected.to contain_augeas('rundeck/web.xml/session-config/session-timeout'). \

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -48,15 +48,15 @@ describe 'rundeck' do
           {
             user: 'A1234',
             group: 'A1234',
-            user_id: '10000',
-            group_id: '10000'
+            user_id: 10_000,
+            group_id: 10_000
           }
         end
 
         it do
           is_expected.to contain_group('A1234').with(
             'ensure' => 'present',
-            'gid' => '10000'
+            'gid' => 10_000
           )
         end
 

--- a/spec/defines/config/resource_source_spec.rb
+++ b/spec/defines/config/resource_source_spec.rb
@@ -23,7 +23,7 @@ describe 'rundeck::config::resource_source', type: :define do
             'include_server_node' => false,
             'resource_format' => 'resourcexml',
             'url_cache' => true,
-            'url_timeout' => '50',
+            'url_timeout' => 50,
             'directory' => '/',
             'script_args_quoted' => true,
             'script_interpreter' => '/bin/bash'
@@ -66,7 +66,7 @@ describe 'rundeck::config::resource_source', type: :define do
             'url' => 'http\://localhost\:9999',
             'include_server_node' => true,
             'url_cache' => true,
-            'url_timeout' => '50',
+            'url_timeout' => 50,
             'directory' => '/',
             'resource_format' => 'resourcexml',
             'script_args_quoted' => true,
@@ -102,7 +102,7 @@ describe 'rundeck::config::resource_source', type: :define do
             'include_server_node' => true,
             'resource_format' => 'resourcexml',
             'url_cache' => true,
-            'url_timeout' => '50',
+            'url_timeout' => 50,
             'script_args_quoted' => true,
             'script_interpreter' => '/bin/bash'
 
@@ -138,7 +138,7 @@ describe 'rundeck::config::resource_source', type: :define do
             'script_args_quoted' => true,
             'script_interpreter' => '/bin/bash',
             'url_cache' => true,
-            'url_timeout' => '30',
+            'url_timeout' => 30,
             'directory' => '/'
           }
         end
@@ -171,15 +171,15 @@ describe 'rundeck::config::resource_source', type: :define do
             'include_server_node' => false,
             'resource_format' => 'resourcexml',
             'url_cache' => true,
-            'url_timeout' => '50',
+            'url_timeout' => 50,
             'directory' => '/foo/bar/resources',
             'script_args_quoted' => true,
             'script_interpreter' => '/bin/bash',
 
             'source_type' => 'puppet-enterprise',
             'puppet_enterprise_host' => 'localhost',
-            'puppet_enterprise_port' => '8081',
-            'puppet_enterprise_metrics_interval' => '15',
+            'puppet_enterprise_port' => 8081,
+            'puppet_enterprise_metrics_interval' => 15,
             'puppet_enterprise_mapping_file' => '/var/local/resource-mapping.json',
             'puppet_enterprise_ssl_dir' => '/opt/rundeck/puppetmaster_ssl'
           }

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,0 +1,1 @@
+type Rundeck::Loglevel = Enum['ALL', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'OFF', 'TRACE', 'WARN']

--- a/types/sourcetype.pp
+++ b/types/sourcetype.pp
@@ -1,0 +1,1 @@
+type Rundeck::Sourcetype = Enum['file', 'directory', 'url', 'script', 'aws-ec2', 'puppet-enterprise']


### PR DESCRIPTION
This removes almost all of the `validate_` calls (there's a custom function specific to this module that will probably need to stay, and not sure what to do about `validate_absolute_path($projects_dir)` in `manifests/config/resource_source.pp`, since it's not a param (I think it can probably just be removed, but leaving just in case).

May still need some review / fixes