### PR TITLE
changed requirements for puppet-archive to allow version 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/java_ks",


### PR DESCRIPTION
Looks like it's not breaking anything. As far as I can see it is only used in the rundeck::config::plugin class.
