### PR TITLE
add rolePrefix attribute to LDAP and Active Directory authentication

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -195,6 +195,7 @@ class rundeck::params {
       'role_name_attribute'     => 'cn',
       'role_member_attribute'   => 'memberUid',
       'role_object_class'       => 'group',
+      'role_prefix'             => undef,
       'nested_groups'           => true,
     },
     'active_directory' => {
@@ -213,6 +214,7 @@ class rundeck::params {
       'role_name_attribute'     => 'cn',
       'role_member_attribute'   => 'member',
       'role_object_class'       => 'group',
+      'role_prefix'             => undef,
       'supplemental_roles'      => 'user',
       'nested_groups'           => true,
     },

--- a/spec/classes/config/global/auth_spec.rb
+++ b/spec/classes/config/global/auth_spec.rb
@@ -241,6 +241,44 @@ describe 'rundeck' do
           expect(jaas_auth).to include(login_module)
         end
       end
+
+      describe 'ldap with rolePrefix' do
+        let(:params) do
+          {
+            auth_types: %w[ldap],
+            auth_config: {
+              'ldap' => {
+                'url'         => 'localhost:389',
+                'role_prefix' => 'rundeck_'
+              }
+            }
+          }
+        end
+
+        it 'generates valid content for jaas-auth.conf' do
+          content = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+          expect(content).to include('rolePrefix="rundeck_"')
+        end
+      end
+
+      describe 'active_directory with rolePrefix' do
+        let(:params) do
+          {
+            auth_types: %w[active_directory],
+            auth_config: {
+              'active_directory' => {
+                'url'         => 'localhost:389',
+                'role_prefix' => 'rundeck_'
+              }
+            }
+          }
+        end
+
+        it 'generates valid content for jaas-auth.conf' do
+          content = catalogue.resource('file', '/etc/rundeck/jaas-auth.conf')[:content]
+          expect(content).to include('rolePrefix="rundeck_"')
+        end
+      end
     end
   end
 end

--- a/templates/_auth_ad.erb
+++ b/templates/_auth_ad.erb
@@ -30,6 +30,9 @@ provider_url =
   roleNameAttribute="<%= @auth_config['active_directory']['role_name_attribute'] %>"
   roleMemberAttribute="<%= @auth_config['active_directory']['role_member_attribute'] %>"
   roleObjectClass="<%= @auth_config['active_directory']['role_object_class'] %>"
+  <%- if @auth_config['active_directory']['role_prefix'] -%>
+  rolePrefix="<%= @auth_config['active_directory']['role_prefix'] %>"
+  <%- end -%>
   <%- if @auth_config['active_directory']['supplemental_roles'] -%>
   supplementalRoles="<%= @auth_config['active_directory']['supplemental_roles'] %>"
   <%- end -%>

--- a/templates/_auth_ldap.erb
+++ b/templates/_auth_ldap.erb
@@ -26,8 +26,11 @@ provider_url =
   userBaseDn="<%= @auth_config['ldap']['user_base_dn'] %>"
   userRdnAttribute="<%= @auth_config['ldap']['user_rdn_attribute'] %>"
   userIdAttribute="<%= @auth_config['ldap']['user_id_attribute'] %>"
-  userPasswordAttribute="<%= @auth_config['ldap']['user_password_attribute'] %>" 
+  userPasswordAttribute="<%= @auth_config['ldap']['user_password_attribute'] %>"
   userObjectClass="<%= @auth_config['ldap']['user_object_class'] %>"
+<%- if @auth_config['ldap']['role_prefix'] -%>
+  rolePrefix="<%= @auth_config['ldap']['role_prefix'] %>"
+<%- end -%>
   roleBaseDn="<%= @auth_config['ldap']['role_base_dn'] %>"
   roleNameAttribute="<%= @auth_config['ldap']['role_name_attribute'] %>"
 <%- if @auth_config['ldap']['role_username_member_attribute'] -%>
@@ -39,7 +42,7 @@ provider_url =
 <%- if @auth_config['ldap']['supplemental_roles'] != :undef -%>
   supplementalRoles="<%= @auth_config['ldap']['supplemental_roles'] %>"
 <%- end -%>
-<%- 
+<%-
 cache_duration_ms =
   if @auth_config['ldap']['cache_duration_millis']
     @auth_config['ldap']['cache_duration_millis']


### PR DESCRIPTION
I'm using rolePrefix to map Active Directory groups to Rundeck roles.  This has been working in production AD and LDAP environments.