### PR TITLE
Breaking: Don't manage user / group by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ Array value if you want to have more role in web.xml
 
 Whether to manage the bintray YUM/APT repository containing the Rundeck rpm/deb. Defaults to true. 
 
+##### `manage_group`
+
+Whether to manage `group` (and enforce `group_id` if set). Defaults to false.
+
+##### `manage_user`
+
+Whether to manage `user` (and enforce `user_id` if set). Defaults to false.
+
 ##### `file_keystorage_dir`
 
 The location of stored data like public keys, private keys.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,7 @@ class rundeck::config {
   $rd_loglevel                  = $rundeck::rd_loglevel
   $rd_auditlevel                = $rundeck::rd_auditlevel
   $rdeck_config_template        = $rundeck::rdeck_config_template
+  $rdeck_home                   = $rundeck::rdeck_home
   $rdeck_profile_template       = $rundeck::rdeck_profile_template
   $realm_template               = $rundeck::realm_template
   $rss_enabled                  = $rundeck::rss_enabled
@@ -77,8 +78,27 @@ class rundeck::config {
   $rdeck_base     = $framework_config['rdeck.base']
   $projects_dir   = $framework_config['framework.projects.dir']
   $properties_dir = $framework_config['framework.etc.dir']
+  $plugin_dir     = $framework_config['framework.libext.dir']
 
-  #
+  File[$rdeck_home] ~> File[$framework_config['framework.ssh.keypath']]
+
+  file { $rdeck_home:
+    ensure  => directory,
+  }
+
+  if $rundeck::sshkey_manage {
+    file { $framework_config['framework.ssh.keypath']:
+      mode    => '0600',
+    }
+  }
+
+  file { $rundeck::service_logs_dir:
+    ensure  => directory,
+  }
+
+  ensure_resource(file, $projects_dir, {'ensure' => 'directory'})
+  ensure_resource(file, $plugin_dir, {'ensure'   => 'directory'})
+
   # Checking if we need to deploy realm file
   #  ugly, I know. Fix it if you know better way to do that
   #

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -112,7 +112,6 @@ class rundeck::config {
     file { "${properties_dir}/realm.properties":
       content => template($realm_template),
       require => File[$properties_dir],
-      notify  => Service[$service_name],
     }
   }
 
@@ -149,7 +148,6 @@ class rundeck::config {
 
   file { "${properties_dir}/log4j.properties":
     content => template($log_properties_template),
-    notify  => Service[$service_name],
     require => File[$properties_dir],
   }
 
@@ -176,14 +174,12 @@ class rundeck::config {
   if ($rdeck_profile_template) {
     file { "${properties_dir}/profile":
       content => template($rdeck_profile_template),
-      notify  => Service[$service_name],
       require => File[$properties_dir],
     }
   }
 
   file { "${overrides_dir}/${service_name}":
     content => template('rundeck/profile_overrides.erb'),
-    notify  => Service[$service_name],
   }
 
   contain rundeck::config::global::framework
@@ -209,7 +205,6 @@ class rundeck::config {
     session_timeout              => $session_timeout,
     security_roles_array_enabled => $security_roles_array_enabled,
     security_roles_array         => $security_roles_array,
-    notify                       => Service[$service_name],
     require                      => Class['rundeck::install'],
   }
 
@@ -219,7 +214,6 @@ class rundeck::config {
       group   => $group,
       mode    => '0640',
       content => template('rundeck/krb5.conf.erb'),
-      notify  => Service[$service_name],
       require => File[$properties_dir],
     }
   }

--- a/manifests/config/global/ssl.pp
+++ b/manifests/config/global/ssl.pp
@@ -43,7 +43,6 @@ class rundeck::config::global::ssl {
     password     => $keystore_password,
     destkeypass  => $key_password,
     trustcacerts => true,
-    notify       => Service[$service_name],
   }
   -> java_ks { "rundeck:${properties_dir}/ssl/truststore":
     ensure       => present,
@@ -52,11 +51,6 @@ class rundeck::config::global::ssl {
     password     => $truststore_password,
     destkeypass  => $key_password,
     trustcacerts => true,
-    notify       => Service[$service_name],
-  }
-
-  Ini_setting {
-    notify => Service[$service_name],
   }
 
   file { $properties_file:
@@ -64,7 +58,6 @@ class rundeck::config::global::ssl {
     owner   => $user,
     group   => $group,
     mode    => '0640',
-    notify  => Service[$service_name],
     require => File[$properties_dir],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,14 @@
 # [*manage_default_api_policy*]
 #  Boolean value if set to true enables default api policy management
 #
+# [*manage_group*]
+#
+# Whether to manage `group` (and enforce `group_id` if set). Defaults to false.
+#
+# [*manage_user*]
+#
+# Whether to manage `user` (and enforce `user_id` if set). Defaults to false.
+#
 # [*package_ensure*]
 #  Ensure the state of the rundeck package, either present, absent or a specific version
 #
@@ -209,7 +217,6 @@ class rundeck (
   Hash $file_keystorage_keys                          = $rundeck::params::file_keystorage_keys,
   Hash $framework_config                              = $rundeck::params::framework_config,
   Stdlib::HTTPUrl $grails_server_url                  = $rundeck::params::grails_server_url,
-  String $group                                       = $rundeck::params::group,
   Hash $gui_config                                    = $rundeck::params::gui_config,
   Optional[Stdlib::Absolutepath] $java_home           = undef,
   String $jvm_args                                    = $rundeck::params::jvm_args,
@@ -259,6 +266,9 @@ class rundeck (
   Stdlib::Absolutepath $truststore                    = $rundeck::params::truststore,
   String $truststore_password                         = $rundeck::params::truststore_password,
   String $user                                        = $rundeck::params::user,
+  String $group                                       = $rundeck::params::group,
+  Boolean $manage_user                                = $rundeck::params::manage_user,
+  Boolean $manage_group                               = $rundeck::params::manage_group,
   Optional[Integer] $user_id                          = undef,
   Optional[Integer] $group_id                         = undef,
   Boolean $security_roles_array_enabled               = $rundeck::params::security_roles_array_enabled,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -250,6 +250,9 @@ class rundeck::params {
   $script_args_quoted = true
   $script_interpreter = '/bin/bash'
 
+  $manage_user = false
+  $manage_group = false
+
   $user = 'rundeck'
   $group = 'rundeck'
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -13,6 +13,8 @@ describe 'rundeck' do
       end
 
       describe "rundeck::config class without any parameters on #{os}" do
+        it { is_expected.to contain_file('/var/lib/rundeck').with('ensure' => 'directory') }
+        it { is_expected.to contain_file('/var/lib/rundeck/libext').with('ensure' => 'directory') }
         it { is_expected.to contain_class('rundeck::config::global::framework') }
         it { is_expected.to contain_class('rundeck::config::global::project') }
         it { is_expected.to contain_class('rundeck::config::global::rundeck_config') }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -10,13 +10,15 @@ describe 'rundeck' do
       describe "rundeck class without any parameters on #{os}" do
         let(:params) { {} }
 
-        plugin_dir = '/var/lib/rundeck/libext'
-
-        it { is_expected.to contain_file('/var/lib/rundeck').with('ensure' => 'directory') }
-
-        it { is_expected.to contain_file(plugin_dir).with('ensure' => 'directory') }
-
-        it { is_expected.to contain_user('rundeck').with('ensure' => 'present') }
+        it { is_expected.not_to contain_user('rundeck') }
+        it do
+          is_expected.to contain_file('/var/rundeck').with(
+            ensure: 'directory',
+            owner: 'rundeck',
+            group: 'rundeck',
+            recurse: true
+          )
+        end
 
         case facts[:os]['family']
         when 'RedHat'
@@ -36,6 +38,8 @@ describe 'rundeck' do
       describe 'different user and group' do
         let(:params) do
           {
+            manage_user: true,
+            manage_group: true,
             user: 'A1234',
             group: 'A1234'
           }
@@ -52,6 +56,8 @@ describe 'rundeck' do
       describe 'different user and group with ids' do
         let(:params) do
           {
+            manage_user: true,
+            manage_group: true,
             user: 'A1234',
             group: 'A1234',
             user_id: 10_000,


### PR DESCRIPTION
This introduces new params `manage_user` and `manage_group`, disabled by default (as the package should create the Rundeck user already).

There may still be problems with some corner cases; setting alternate usernames or trying to change the username with different UIDs (or change the numeric UID for the Rundeck user while Rundeck is running) may cause errors and / or idempotency issues -- but I think it's at least a big improvement over the previous logic.

This also simplifies the logic around user creation a bit now that there are data types.

It moves some items that used to be handled in the install class to the config class, and removes direct notifies of the service from config class, since the config class as a whole notifies `rundeck::service`