### PR TITLE
Use gpgkey for rpm (#205), remove package_source param, add new params for repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ The log4j logging level to be set for the Rundeck application.
 
 Allows you to use your own profile template instead of the default from the package maintainer
 
+##### `repo_apt_key_id`
+
+Key ID for the GPG key for the Debian package
+
+##### `repo_apt_keyserver`
+
+Keysever for the GPG key for the Debian package
+
+##### `repo_apt_source`
+
+Baseurl for the apt repo
+
+##### `repo_yum_gpgkey`
+
+URL or path for the GPG key for the rpm
+
+##### `repo_yum_source`
+
+Baseurl for the yum repo
+
 ##### `rss_enabled`
 
 Boolean value if set to true enables RSS feeds that are public (non-authenticated)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,26 @@
 # [*grails_server_url*]
 #  Sets `grails.serverURL` so that Rundeck knows its external address.
 #
+# [*repo_apt_key_id*]
+#
+# Key ID for the GPG key for the Debian package
+#
+# [*repo_apt_keyserver*]
+#
+# Keysever for the GPG key for the Debian package
+#
+# [*repo_apt_source*]
+#
+# Baseurl for the apt repo
+#
+# [*repo_yum_gpgkey*]
+#
+# URL or path for the GPG key for the rpm
+#
+# [*repo_yum_source*]
+#
+# Baseurl for the yum repo
+#
 # [*ssl_keyfile*]
 #  Full path to the SSL private key to be used by Rundeck.
 #
@@ -207,7 +227,6 @@ class rundeck (
   Boolean $manage_default_api_policy                  = $rundeck::params::manage_default_api_policy,
   Boolean $manage_repo                                = $rundeck::params::manage_repo,
   String $package_ensure                              = $rundeck::params::package_ensure,
-  Stdlib::HTTPUrl $package_source                     = $rundeck::params::package_source,
   Hash $preauthenticated_config                       = $rundeck::params::preauthenticated_config,
   Hash $projects                                      = $rundeck::params::projects,
   String $projects_description                        = $rundeck::params::projects_default_desc,
@@ -220,6 +239,11 @@ class rundeck (
   Stdlib::Absolutepath $rdeck_home                    = $rundeck::params::rdeck_home,
   Optional[String] $rdeck_profile_template            = undef,
   String $realm_template                              = $rundeck::params::realm_template,
+  Stdlib::HTTPUrl $repo_yum_source                    = $rundeck::params::repo_yum_source,
+  String $repo_yum_gpgkey                             = $rundeck::params::repo_yum_gpgkey,
+  Stdlib::HTTPUrl $repo_apt_source                    = $rundeck::params::repo_apt_source,
+  String $repo_apt_key_id                             = $rundeck::params::repo_apt_key_id,
+  String $repo_apt_keyserver                          = $rundeck::params::repo_apt_keyserver,
   Boolean $rss_enabled                                = $rundeck::params::rss_enabled,
   Hash $security_config                               = $rundeck::params::security_config,
   String $security_role                               = $rundeck::params::security_role,
@@ -228,7 +252,7 @@ class rundeck (
   Stdlib::Absolutepath $service_logs_dir              = $rundeck::params::service_logs_dir,
   String $service_name                                = $rundeck::params::service_name,
   Optional[String] $service_script                    = undef,
-  String $service_ensure                              = $rundeck::params::service_ensure,
+  Enum['stopped', 'running'] $service_ensure          = $rundeck::params::service_ensure,
   Integer $session_timeout                            = $rundeck::params::session_timeout,
   Boolean $ssl_enabled                                = $rundeck::params::ssl_enabled,
   Integer $ssl_port                                   = $rundeck::params::ssl_port,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,10 +10,14 @@ class rundeck::install {
 
   assert_private()
 
-  $manage_repo    = $rundeck::manage_repo
-  $package_ensure = $rundeck::package_ensure
-  $package_source = $rundeck::package_source
-  $rdeck_home     = $rundeck::rdeck_home
+  $manage_repo        = $rundeck::manage_repo
+  $package_ensure     = $rundeck::package_ensure
+  $repo_yum_source    = $rundeck::repo_yum_source
+  $repo_yum_gpgkey    = $rundeck::repo_yum_gpgkey
+  $repo_apt_source    = $rundeck::repo_apt_source
+  $repo_apt_key_id    = $rundeck::repo_apt_key_id
+  $repo_apt_keyserver = $rundeck::repo_apt_keyserver
+  $rdeck_home         = $rundeck::rdeck_home
 
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)
   $projects_dir     = $framework_config['framework.projects.dir']
@@ -32,12 +36,13 @@ class rundeck::install {
 
   case $::osfamily {
     'RedHat': {
-      if $manage_repo == true {
+      if $manage_repo {
         yumrepo { 'bintray-rundeck':
-          baseurl  => 'http://dl.bintray.com/rundeck/rundeck-rpm/',
+          baseurl  => $repo_yum_source,
           descr    => 'bintray rundeck repo',
           enabled  => '1',
-          gpgcheck => '0',
+          gpgcheck => '1',
+          gpgkey   => $repo_yum_gpgkey,
           priority => '1',
           before   => Package['rundeck'],
         }
@@ -46,15 +51,15 @@ class rundeck::install {
       ensure_packages(['rundeck', 'rundeck-config'], {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     'Debian': {
-      if $manage_repo == true {
+      if $manage_repo {
         include apt
         apt::source { 'bintray-rundeck':
-          location => 'https://dl.bintray.com/rundeck/rundeck-deb',
+          location => $repo_apt_source,
           release  => '/',
           repos    => '',
           key      => {
-            id     => '8756C4F765C9AC3CB6B85D62379CE192D401AB61',
-            server => 'keyserver.ubuntu.com',
+            id     => $repo_apt_key_id,
+            server => $repo_apt_keyserver,
           },
           before   => Package['rundeck'],
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,11 @@ class rundeck::params {
   $package_ensure = 'installed'
   $service_name = 'rundeckd'
   $manage_repo = true
+  $repo_yum_source = 'http://dl.bintray.com/rundeck/rundeck-rpm/'
+  $repo_yum_gpgkey = 'https://bintray.com/user/downloadSubjectPublicKey?username=rundeck'
+  $repo_apt_source = 'https://dl.bintray.com/rundeck/rundeck-deb'
+  $repo_apt_key_id = '8756C4F765C9AC3CB6B85D62379CE192D401AB61'
+  $repo_apt_keyserver = 'keyserver.ubuntu.com'
 
   case $::osfamily {
     'Debian': {
@@ -296,8 +301,6 @@ class rundeck::params {
 
   $ssl_keyfile = '/etc/rundeck/ssl/rundeck.key'
   $ssl_certfile = '/etc/rundeck/ssl/rundeck.crt'
-
-  $package_source = 'https://dl.bintray.com/rundeck/rundeck-deb'
 
   $web_xml = "${rdeck_base}/exp/webapp/WEB-INF/web.xml"
   $security_role = 'user'

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -20,7 +20,13 @@ describe 'rundeck' do
 
         case facts[:os]['family']
         when 'RedHat'
-          it { is_expected.to contain_yumrepo('bintray-rundeck') }
+          it do
+            is_expected.to contain_yumrepo('bintray-rundeck').with(
+              baseurl: 'http://dl.bintray.com/rundeck/rundeck-rpm/',
+              gpgcheck: 1,
+              gpgkey: 'https://bintray.com/user/downloadSubjectPublicKey?username=rundeck'
+            ).that_comes_before('Package[rundeck]')
+          end
         when 'Debian'
           it { is_expected.to contain_apt__source('bintray-rundeck').with_location('https://dl.bintray.com/rundeck/rundeck-deb') }
           it { is_expected.to contain_package('rundeck').that_notifies('Class[rundeck::service]') }


### PR DESCRIPTION
This:
- Adds the GPG check for rpm packages (though with a default source at the same repo the package is from
- Adds the ability to control key ID / keyserver (apt), key source (rpm), and repo sources, with the existing defaults in params (the repo is still named bintray-rundeck, though, even though someone could theoretically specify a different one)
- Removes the unused package_source parameter
- Improves test coverage slightly

Because of the last point, we can probably label this as breaking, though the param seems to already have been unused.