### PR TITLE
Create a simple project with default values in the acceptance test

### DIFF
--- a/spec/acceptance/rundeck_spec.rb
+++ b/spec/acceptance/rundeck_spec.rb
@@ -25,4 +25,25 @@ describe 'rundeck class' do
       it { is_expected.to be_running }
     end
   end
+
+  context 'simple project' do
+    it 'applies successfully' do
+      pp = <<-EOS
+      class { 'rundeck':
+        projects => {
+          'Wizzle' => {},
+        }
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/var/lib/rundeck/projects/Wizzle/etc/project.properties') do
+      it { is_expected.to be_file }
+      its(:content) { is_expected.to match %r{service.FileCopier.default.provider = jsch-scp} }
+    end
+  end
 end


### PR DESCRIPTION
There's probably room for a lot more testing (would be cool to even create an API token and make a test call to it).

This is a start to doing a bit more testing, by creating a project and verifying some basics about it.

I also tried verifying that it's listening on the right port, but I don't want to add a sleep, and the port isn't listening yet at the point where the test runs.