### PR TITLE
Bump stdlib to 4.21.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.15.0 < 5.0.0"
+      "version_requirement": ">= 4.21.0 < 5.0.0"
     },
     {
       "name": "pltraining/dirtree",


### PR DESCRIPTION
$default_resource_dir is set to '/' by default.
stdlib versions earlier than 4.21.0 do not accept this for the
Stdlib::Absolutepath data type

Fixes #362 