### PR TITLE
Ensure repos are set up before installing rundeck-config

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,7 +63,7 @@ class rundeck::install {
           gpgcheck => '1',
           gpgkey   => $repo_yum_gpgkey,
           priority => '1',
-          before   => Package['rundeck'],
+          before   => Package['rundeck', 'rundeck-config'],
         }
       }
 


### PR DESCRIPTION
This fixes an issue where initial setup on RedHat systems can require two puppet runs.