### PR TITLE
Adding hiera support for log_properties_template

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,7 +67,7 @@ class rundeck::params {
   $auth_users = {}
   $auth_template = 'rundeck/jaas-auth.conf.erb'
 
-  $log_properties_template = 'rundeck/log4j.properties.erb'
+  $log_properties_template = hiera('rundeck::params::log_properties_template','rundeck/log4j.properties.erb')
 
   $acl_template = 'rundeck/aclpolicy.erb'
   $api_template = 'rundeck/aclpolicy.erb'


### PR DESCRIPTION
I'm trying to implement this change in order to support changing log4j config template to support different logging options such as removing log rotation when inheriting this module into private ones.