### PR TITLE
Creating the home dir is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ Whether to manage `group` (and enforce `group_id` if set). Defaults to false.
 
 Whether to manage `user` (and enforce `user_id` if set). Defaults to false.
 
+##### `manage_home`
+
+Whether to create the `rundeck_home` directory. Defaults to true.
+
 ##### `file_keystorage_dir`
 
 The location of stored data like public keys, private keys.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,6 +46,7 @@ class rundeck::config {
   $rd_auditlevel                = $rundeck::rd_auditlevel
   $rdeck_config_template        = $rundeck::rdeck_config_template
   $rdeck_home                   = $rundeck::rdeck_home
+  $manage_home                  = $rundeck::manage_home
   $rdeck_profile_template       = $rundeck::rdeck_profile_template
   $realm_template               = $rundeck::realm_template
   $rss_enabled                  = $rundeck::rss_enabled
@@ -82,8 +83,12 @@ class rundeck::config {
 
   File[$rdeck_home] ~> File[$framework_config['framework.ssh.keypath']]
 
-  file { $rdeck_home:
-    ensure  => directory,
+  if $manage_home {
+    file{ $rdeck_home:
+      ensure  => directory,
+    }
+  } elsif ! defined_with_params(File[$rdeck_home], {'ensure' => 'directory' }) {
+    fail('when rundeck::manage_home = false a file definition for the home directory must be included outside of this module.')
   }
 
   if $rundeck::sshkey_manage {
@@ -91,6 +96,7 @@ class rundeck::config {
       mode    => '0600',
     }
   }
+
 
   file { $rundeck::service_logs_dir:
     ensure  => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -244,6 +244,7 @@ class rundeck (
   Rundeck::Loglevel $rd_auditlevel                    = $rundeck::params::loglevel,
   String $rdeck_config_template                       = $rundeck::params::rdeck_config_template,
   Stdlib::Absolutepath $rdeck_home                    = $rundeck::params::rdeck_home,
+  Boolean $manage_home                                = $rundeck::params::manage_home,
   Optional[String] $rdeck_profile_template            = undef,
   String $realm_template                              = $rundeck::params::realm_template,
   Stdlib::HTTPUrl $repo_yum_source                    = $rundeck::params::repo_yum_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,7 @@ class rundeck::params {
 
   $rdeck_base = '/var/lib/rundeck'
   $rdeck_home = '/var/lib/rundeck'
+  $manage_home = true
   $service_logs_dir = '/var/log/rundeck'
 
   $rdeck_uuid = $facts['serialnumber'] ? {

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -74,6 +74,19 @@ describe 'rundeck' do
           expect(content).to include("RDECK_JVM_SETTINGS=\"#{jvm_args}\"")
         end
       end
+
+      describe 'rundeck::config with manage_home=false with external homedir file resource' do
+        let(:pre_condition) { 'File{"/var/lib/rundeck": ensure => directory }' }
+        let(:params) { { manage_home: false } }
+
+        it { is_expected.to contain_file('/var/lib/rundeck').that_comes_before('File[/var/lib/rundeck/.ssh/id_rsa]') }
+      end
+
+      describe 'rundeck::config with manage_home=false but no external homedir file resource' do
+        let(:params) { { manage_home: false } }
+
+        it { is_expected.to raise_error(Puppet::PreformattedError, %r{when rundeck::manage_home = false a file definition for the home directory must be included outside of this module.}) }
+      end
     end
   end
 end


### PR DESCRIPTION
manage_home will determine if the home directory is managed.

Usefull for us, because we needed to bind mount the homedir.
This meant that the mount and directory needed to exist
before executing the rundeck module.

