### PR TITLE
Fix default project attribute names

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,8 +38,8 @@ class rundeck::config {
   $overrides_dir                = $rundeck::overrides_dir
   $preauthenticated_config      = $rundeck::preauthenticated_config
   $projects                     = $rundeck::projects
-  $projects_description         = $rundeck::projects_default_desc
-  $projects_organization        = $rundeck::projects_default_org
+  $projects_description         = $rundeck::projects_description
+  $projects_organization        = $rundeck::projects_organization
   $projects_storage_type        = $rundeck::projects_storage_type
   $quartz_job_threadcount       = $rundeck::quartz_job_threadcount
   $rd_loglevel                  = $rundeck::rd_loglevel


### PR DESCRIPTION
#### Pull Request (PR) description

This fixes the default project description and organization.

Currently the `rundeck` class pulls in defaults for `projects_description` and `projects_organization` from `rundeck::params`, then `rundeck::config` attempts to pull them out of `rundeck` using the wrong name.  The result is that when calling `rundeck` and providing `projects_description` and/or `projects_organization`, those values are not used, and the defaults from `rundeck::params` are used instead.

This simply fixes the names that `rundeck::config` is using to pull the the description and organization from `rundeck`.

#### This Pull Request (PR) fixes the following issues
n/a
