### PR TITLE
pin rundeck to version 2.11.5

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@
 #
 class rundeck::params {
   $package_name = 'rundeck'
-  $package_ensure = 'installed'
+  $package_ensure = '2.11.5'
   $service_name = 'rundeckd'
   $manage_repo = true
   $repo_yum_source = 'http://dl.bintray.com/rundeck/rundeck-rpm/'

--- a/spec/acceptance/rundeck_spec.rb
+++ b/spec/acceptance/rundeck_spec.rb
@@ -8,7 +8,7 @@ describe 'rundeck class' do
         distribution => 'jre'
       }
       class { 'rundeck':
-        package_ensure => '2.9.4'
+        package_ensure => '2.11.5'
       }
 
       Class['java'] -> Class['rundeck']
@@ -32,7 +32,7 @@ describe 'rundeck class' do
     it 'applies successfully' do
       pp = <<-EOS
       class { 'rundeck':
-        package_ensure => '2.9.4',
+        package_ensure => '2.11.5',
         projects => {
           'Wizzle' => {},
         }


### PR DESCRIPTION
This is the latest 2.X version. 3.X got recently released, but requires
some changes to our module. To keep it working for now, we pin it to 2.9.4.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
