### PR TITLE
Add support for rundeck 3.x

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,6 +36,7 @@ class rundeck::config {
   $manage_default_admin_policy  = $rundeck::manage_default_admin_policy
   $manage_default_api_policy    = $rundeck::manage_default_api_policy
   $overrides_dir                = $rundeck::overrides_dir
+  $package_ensure               = $rundeck::package_ensure
   $preauthenticated_config      = $rundeck::preauthenticated_config
   $projects                     = $rundeck::projects
   $projects_description         = $rundeck::projects_description
@@ -206,12 +207,14 @@ class rundeck::config {
 
   create_resources(rundeck::config::project, $projects)
 
-  class { 'rundeck::config::global::web':
-    security_role                => $security_role,
-    session_timeout              => $session_timeout,
-    security_roles_array_enabled => $security_roles_array_enabled,
-    security_roles_array         => $security_roles_array,
-    require                      => Class['rundeck::install'],
+  if versioncmp( $package_ensure, '3.0.0' ) < 0 {
+    class { 'rundeck::config::global::web':
+      security_role                => $security_role,
+      session_timeout              => $session_timeout,
+      security_roles_array_enabled => $security_roles_array_enabled,
+      security_roles_array         => $security_roles_array,
+      require                      => Class['rundeck::install'],
+    }
   }
 
   if !empty($kerberos_realms) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@
 #
 class rundeck::params {
   $package_name = 'rundeck'
-  $package_ensure = '2.11.5'
+  $package_ensure = 'installed'
   $service_name = 'rundeckd'
   $manage_repo = true
   $repo_yum_source = 'http://dl.bintray.com/rundeck/rundeck-rpm/'

--- a/spec/acceptance/rundeck_spec.rb
+++ b/spec/acceptance/rundeck_spec.rb
@@ -7,9 +7,7 @@ describe 'rundeck class' do
       class { 'java':
         distribution => 'jre'
       }
-      class { 'rundeck':
-        package_ensure => '2.11.5'
-      }
+      class { 'rundeck': }
 
       Class['java'] -> Class['rundeck']
       EOS
@@ -32,7 +30,6 @@ describe 'rundeck class' do
     it 'applies successfully' do
       pp = <<-EOS
       class { 'rundeck':
-        package_ensure => '2.11.5',
         projects => {
           'Wizzle' => {},
         }

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -79,7 +79,8 @@ describe 'rundeck' do
           loglevel.default = "INFO"
           rdeck.base = "/var/lib/rundeck"
           rss.enabled = "false"
-
+          rundeck.log4j.config.file = "/etc/rundeck/log4j.properties"
+          
           rundeck.security.useHMacRequestTokens = true
           rundeck.security.apiCookieAccess.enabled = true
 

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -80,7 +80,7 @@ describe 'rundeck' do
           rdeck.base = "/var/lib/rundeck"
           rss.enabled = "false"
           rundeck.log4j.config.file = "/etc/rundeck/log4j.properties"
-          
+
           rundeck.security.useHMacRequestTokens = true
           rundeck.security.apiCookieAccess.enabled = true
 

--- a/spec/classes/config/global/web_spec.rb
+++ b/spec/classes/config/global/web_spec.rb
@@ -9,15 +9,20 @@ describe 'rundeck' do
       rundeck_version: ''
     }
   end
+  let(:params) do
+    {
+      'package_ensure' => '2.11.5'
+    }
+  end
 
-  context 'with empty params' do
+  context 'rundeck version prior 3.x with empty params' do
     it 'generates augeas resource with default security_role' do
       is_expected.to contain_augeas('rundeck/web.xml/security-role/role-name'). \
         with_changes(["set web-app/security-role/role-name/#text 'user'"])
     end
   end
 
-  context 'with security_role param' do
+  context 'rundeck version prior 3.x with security_role param' do
     let(:params) { { security_role: 'superduper' } }
 
     it 'generates augeas resource with specified security_role' do
@@ -26,7 +31,7 @@ describe 'rundeck' do
     end
   end
 
-  context 'with session_timeout param' do
+  context 'rundeck version prior 3.x with session_timeout param' do
     let(:params) { { session_timeout: 60 } }
 
     it 'generates augeas resource with specified session_timeout' do

--- a/spec/classes/config/global/web_spec.rb
+++ b/spec/classes/config/global/web_spec.rb
@@ -9,13 +9,10 @@ describe 'rundeck' do
       rundeck_version: ''
     }
   end
-  let(:params) do
-    {
-      'package_ensure' => '2.11.5'
-    }
-  end
 
   context 'rundeck version prior 3.x with empty params' do
+    let(:params) { { package_ensure: '2.11.5' } }
+
     it 'generates augeas resource with default security_role' do
       is_expected.to contain_augeas('rundeck/web.xml/security-role/role-name'). \
         with_changes(["set web-app/security-role/role-name/#text 'user'"])
@@ -23,7 +20,7 @@ describe 'rundeck' do
   end
 
   context 'rundeck version prior 3.x with security_role param' do
-    let(:params) { { security_role: 'superduper' } }
+    let(:params) { { package_ensure: '2.11.5', security_role: 'superduper' } }
 
     it 'generates augeas resource with specified security_role' do
       is_expected.to contain_augeas('rundeck/web.xml/security-role/role-name'). \
@@ -32,7 +29,7 @@ describe 'rundeck' do
   end
 
   context 'rundeck version prior 3.x with session_timeout param' do
-    let(:params) { { session_timeout: 60 } }
+    let(:params) { { package_ensure: '2.11.5', session_timeout: 60 } }
 
     it 'generates augeas resource with specified session_timeout' do
       is_expected.to contain_augeas('rundeck/web.xml/session-config/session-timeout'). \

--- a/spec/defines/config/securityroles_spec.rb
+++ b/spec/defines/config/securityroles_spec.rb
@@ -9,6 +9,7 @@ describe 'rundeck::config::securityroles', type: :define do
         let(:title) { 'source one' }
         let(:params) do
           {
+            'package_ensure'               => '2.11.5',
             'security_roles_array_enabled' => true
           }
         end

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -1,6 +1,7 @@
 loglevel.default = "<%= @rd_loglevel %>"
 rdeck.base = "<%= @rdeck_base %>"
 rss.enabled = "<%= @rss_enabled %>"
+rundeck.log4j.config.file = "<%= @properties_dir %>/log4j.properties"
 
 <%- if @security_config.key?('useHMacRequestTokens') -%>
 rundeck.security.useHMacRequestTokens = <%= @security_config['useHMacRequestTokens'] %>


### PR DESCRIPTION
#### Pull Request (PR) description
Quickwin to get rundeck 3.x running without error on:
- no more existant WEB-INF/web.xml 
- log4j.properties file location in rundeck-config.groovy

-> https://rundeck.org/news/2018/07/27/rundeck-3.0.0.html

#### This Pull Request (PR) fixes the following issues

