### PR TITLE
Turn serialnumber into UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ How to: eg: environments/role/manifests/rundeck.pp
 
 class role::rundeck (
 ...
-  $ssl_keyfile                        = hiera('rundeck::config::ssl_keyfile', "/etc/rundeck/ssl/$fqdn.key"),
-  $ssl_certfile                       = hiera('rundeck::config::ssl_certfile', "/etc/rundeck/ssl/$fqdn.crt"),
+  $ssl_keyfile                        = hiera('rundeck::config::ssl_keyfile', "/etc/rundeck/ssl/${facts['fqdn']}.key"),
+  $ssl_certfile                       = hiera('rundeck::config::ssl_certfile', "/etc/rundeck/ssl/${facts['fqdn']}.crt"),
 ..
 ){
 ...

--- a/examples/demo_install_el7.pp
+++ b/examples/demo_install_el7.pp
@@ -5,10 +5,10 @@
 # puppet module install puppetlabs-java
 # puppet module install puppet-rundeck
 # puppet module install crayfishx-firewalld
-# - $::fqdn fact needs to be working
+# - $facts['fqdn'] fact needs to be working
 #
 # After installation:
-# - Webinterface on http://${::fqdn}:4440
+# - Webinterface on http://${facts['fqdn']}:4440
 # - Login with admin/admin
 #
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -55,7 +55,7 @@ class rundeck::install {
     }
   }
 
-  case $::osfamily {
+  case $facts['osfamily'] {
     'RedHat': {
       if $manage_repo {
         yumrepo { 'bintray-rundeck':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class rundeck::params {
   $rdeck_uuid = $facts['serialnumber'] ? {
     '0'     => fqdn_uuid($::fqdn),
     undef   => fqdn_uuid($::fqdn),
-    default => $facts['serialnumber'],
+    default => fqdn_uuid(String($facts['serialnumber'])),
   }
 
   $framework_config = {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class rundeck::params {
   $repo_apt_key_id = '8756C4F765C9AC3CB6B85D62379CE192D401AB61'
   $repo_apt_keyserver = 'keyserver.ubuntu.com'
 
-  case $::osfamily {
+  case $facts['osfamily'] {
     'Debian': {
       $overrides_dir = '/etc/default'
     }
@@ -39,10 +39,10 @@ class rundeck::params {
   $service_logs_dir = '/var/log/rundeck'
 
   $framework_config = {
-    'framework.server.name'     => $::fqdn,
-    'framework.server.hostname' => $::fqdn,
+    'framework.server.name'     => $facts['fqdn'],
+    'framework.server.hostname' => $facts['fqdn'],
     'framework.server.port'     => '4440',
-    'framework.server.url'      => "http://${::fqdn}:4440",
+    'framework.server.url'      => "http://${facts['fqdn']}:4440",
     'framework.server.username' => 'admin',
     'framework.server.password' => 'admin',
     'rdeck.base'                => '/var/lib/rundeck',
@@ -55,7 +55,7 @@ class rundeck::params {
     'framework.ssh.keypath'     => '/var/lib/rundeck/.ssh/id_rsa',
     'framework.ssh.user'        => 'rundeck',
     'framework.ssh.timeout'     => '0',
-    'rundeck.server.uuid'       => fqdn_uuid($::fqdn),
+    'rundeck.server.uuid'       => fqdn_uuid($facts['fqdn']),
   }
 
   $auth_types = ['file']
@@ -258,7 +258,7 @@ class rundeck::params {
 
   $clustermode_enabled = false
 
-  $grails_server_url = "http://${::fqdn}:4440"
+  $grails_server_url = "http://${facts['fqdn']}:4440"
 
   $database_config = {
     'type'            => 'h2',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,12 +38,6 @@ class rundeck::params {
   $manage_home = true
   $service_logs_dir = '/var/log/rundeck'
 
-  $rdeck_uuid = $facts['serialnumber'] ? {
-    '0'     => fqdn_uuid($::fqdn),
-    undef   => fqdn_uuid($::fqdn),
-    default => fqdn_uuid(String($facts['serialnumber'])),
-  }
-
   $framework_config = {
     'framework.server.name'     => $::fqdn,
     'framework.server.hostname' => $::fqdn,
@@ -61,7 +55,7 @@ class rundeck::params {
     'framework.ssh.keypath'     => '/var/lib/rundeck/.ssh/id_rsa',
     'framework.ssh.user'        => 'rundeck',
     'framework.ssh.timeout'     => '0',
-    'rundeck.server.uuid'       => $rdeck_uuid,
+    'rundeck.server.uuid'       => fqdn_uuid($::fqdn),
   }
 
   $auth_types = ['file']

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -64,43 +64,14 @@ describe 'rundeck' do
         end
 
         describe 'uuid setting' do
-          context 'when serialnumber fact present' do
-            let :facts do
-              facts.merge(fqdn: 'rundeck.example.com',
-                          serialnumber: '32142097') # uuid is e13e0e7e-b640-5630-b5ff-b3c4559bd1a8
-            end
-
-            it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
-            it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
-              content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
-              expect(content).to include('rundeck.server.uuid = e13e0e7e-b640-5630-b5ff-b3c4559bd1a8')
-            end
+          let :facts do
+            facts.merge(fqdn: 'rundeck.example.com') # uuid is ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0
           end
 
-          context 'when serialnumber fact absent' do
-            let :facts do
-              facts.merge(fqdn: 'rundeck.example.com', # uuid is ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0
-                          serialnumber: nil)
-            end
-
-            it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
-            it 'uses fqdn fact for \'rundeck.server.uuid\'' do
-              content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
-              expect(content).to include('rundeck.server.uuid = ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0')
-            end
-          end
-
-          context 'when serialnumber is \'0\'' do
-            let :facts do
-              facts.merge(fqdn: 'rundeck.example.com', # uuid is ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0
-                          serialnumber: '0')
-            end
-
-            it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
-            it 'uses fqdn fact for \'rundeck.server.uuid\'' do
-              content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
-              expect(content).to include('rundeck.server.uuid = ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0')
-            end
+          it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
+          it 'uses fqdn fact for \'rundeck.server.uuid\'' do
+            content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
+            expect(content).to include('rundeck.server.uuid = ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0')
           end
         end
       end

--- a/spec/classes/rundeck_spec.rb
+++ b/spec/classes/rundeck_spec.rb
@@ -67,13 +67,13 @@ describe 'rundeck' do
           context 'when serialnumber fact present' do
             let :facts do
               facts.merge(fqdn: 'rundeck.example.com',
-                          serialnumber: '32142097')
+                          serialnumber: '32142097') # uuid is e13e0e7e-b640-5630-b5ff-b3c4559bd1a8
             end
 
             it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
             it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
               content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
-              expect(content).to include('rundeck.server.uuid = 32142097')
+              expect(content).to include('rundeck.server.uuid = e13e0e7e-b640-5630-b5ff-b3c4559bd1a8')
             end
           end
 
@@ -84,7 +84,7 @@ describe 'rundeck' do
             end
 
             it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
-            it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
+            it 'uses fqdn fact for \'rundeck.server.uuid\'' do
               content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
               expect(content).to include('rundeck.server.uuid = ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0')
             end
@@ -97,7 +97,7 @@ describe 'rundeck' do
             end
 
             it { is_expected.to contain_file('/etc/rundeck/framework.properties') }
-            it 'uses serialnumber fact for \'rundeck.server.uuid\'' do
+            it 'uses fqdn fact for \'rundeck.server.uuid\'' do
               content = catalogue.resource('file', '/etc/rundeck/framework.properties')[:content]
               expect(content).to include('rundeck.server.uuid = ac7c2cbd-14fa-5ba3-b3f2-d436e9b8a3b0')
             end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR generates the server UUID from the serial number rather than just using the serial number directly, since serial numbers are rarely valid RFC 4122 UUIDs.

With cluster mode enabled, Rundeck requires that `rundeck.server.uuid` be a valid RFC 4122 UUID ([Rundeck source](https://github.com/rundeck/rundeck/blob/d4d1b189728c82953fae1c6d39b5665f817e3549/rundeckapp/grails-app/conf/BootStrap.groovy#L183-L197)).


#### This Pull Request (PR) fixes the following issues
n/a