### PR TITLE
fix(packages): don't install rundeck-config on rundeck >= 3.1.0

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,11 +65,11 @@ class rundeck::install {
           gpgcheck => '1',
           gpgkey   => $repo_yum_gpgkey,
           priority => '1',
-          before   => Package['rundeck', 'rundeck-config'],
+          before   => Package['rundeck'],
         }
       }
 
-      ensure_packages(['rundeck', 'rundeck-config'], {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
+      ensure_packages(['rundeck'], {'ensure' => $package_ensure, notify => Class['rundeck::service'] } )
     }
     'Debian': {
       if $manage_repo {


### PR DESCRIPTION
fix(packages): don't install rundeck-config on rundeck >= 3.1.0

Package `rundeck-config` has been obsoleted on `Centos/RedHat` since `rundeck` `3.1.0`
The process of obsoleting `puppet-rundeck` seems to be still in progress
https://github.com/rundeck/rundeck/issues/5114
Opened another issue:
https://github.com/rundeck/rundeck/issues/5168