### PR TITLE
Allow setting different default file mode

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,6 +19,7 @@ class rundeck::config {
   $clustermode_enabled          = $rundeck::clustermode_enabled
   $database_config              = $rundeck::database_config
   $execution_mode               = $rundeck::execution_mode
+  $file_default_mode            = $rundeck::file_default_mode
   $file_keystorage_dir          = $rundeck::file_keystorage_dir
   $file_keystorage_keys         = $rundeck::file_keystorage_keys
   $grails_server_url            = $rundeck::grails_server_url
@@ -70,7 +71,7 @@ class rundeck::config {
   File {
     owner  => $user,
     group  => $group,
-    mode   => '0640',
+    mode   => $file_default_mode,
   }
 
   $framework_config = deep_merge($rundeck::params::framework_config, $rundeck::framework_config)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -272,6 +272,7 @@ class rundeck (
   Boolean $manage_group                               = $rundeck::params::manage_group,
   Optional[Integer] $user_id                          = undef,
   Optional[Integer] $group_id                         = undef,
+  String $file_default_mode                           = $rundeck::params::file_default_mode,
   Boolean $security_roles_array_enabled               = $rundeck::params::security_roles_array_enabled,
   Array $security_roles_array                         = $rundeck::params::security_roles_array,
 ) inherits rundeck::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -252,6 +252,7 @@ class rundeck::params {
 
   $user = 'rundeck'
   $group = 'rundeck'
+  $file_default_mode = '0640'
 
   $loglevel = 'INFO'
   $rss_enabled = false


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Allow setting different default file mode

Currently, the module sets the default file permission to 0640 in the config class. This change allows to set it to an arbitrary value.

#### This Pull Request (PR) fixes the following issues
n/a
