### PR TITLE
Add required Vault api version to template

### DIFF
--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -81,6 +81,7 @@ rundeck.storage.provider."1".config.approleSecretId = "<%= @vault_keystorage_app
 rundeck.storage.provider."1".config.approleAuthMount = "<%= @vault_keystorage_approle_authmount %>"
 rundeck.storage.provider."1".config.authBackend = "<%= @vault_keystorage_authbackend %>"
 rundeck.storage.provider."1".removePathPrefix = true
+rundeck.storage.provider."1".config.engineVersion = 2
 <%- else -%>
 rundeck.storage.provider."1".type = "db"
 <%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

In the PR for  #430, the API version was missing. For newer installation we have to set it to "2", which should be default for the Vault plugin anyway, but is seems, that this is not the case, so we have to set it explicit, otherwise we get "permission denied" messages in the Vault access logs.
