### PR TITLE
435 - Update threadCount configuration key

### DIFF
--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -93,7 +93,7 @@ describe 'rundeck' do
           rundeck.clusterMode.enabled = "false"
 
           rundeck.projectsStorageType = "filesystem"
-          quartz.props.threadPool.threadCount = "10"
+          quartz.threadPool.threadCount = "10"
 
           rundeck.storage.provider."1".type = "file"
           rundeck.storage.provider."1".config.baseDir = "/var/lib/rundeck/var/storage"

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -64,7 +64,7 @@ rundeck.executionMode = "<%= @execution_mode %>"
 <%- end -%>
 
 rundeck.projectsStorageType = "<%= @projects_storage_type %>"
-quartz.props.threadPool.threadCount = "<%= @quartz_job_threadcount %>"
+quartz.threadPool.threadCount = "<%= @quartz_job_threadcount %>"
 
 <%- if @key_storage_type == 'file' -%>
 rundeck.storage.provider."1".type = "file"


### PR DESCRIPTION
As described in [rundeck/docs issue 44](https://github.com/rundeck/docs/issues/44), and fixed in [this commit](https://github.com/rundeck/docs/commit/b3cea42e45edf11c70f10a3f34b72bb748bc60e9),
the threadCount configuration key changed from `quartz.props.threadPool.threadCount` to `quartz.threadPool.threadCount`

#### Pull Request (PR) description
Replaces the threadCount configuration key with the correct one (as indicated by a change in rundeck documentation)

#### This Pull Request (PR) fixes the following issues
Fixes #435 

