### PR TITLE
Fix preauth config to work with legacy setups

### DIFF
--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -89,10 +89,16 @@ rundeck.storage.provider."1".path = "/"
 rundeck.security.authorization.preauthenticated.enabled = "<%= @preauthenticated_config['enabled']%>"
 rundeck.security.authorization.preauthenticated.attributeName = "<%= @preauthenticated_config['attributeName']%>"
 rundeck.security.authorization.preauthenticated.delimiter = "<%= @preauthenticated_config['delimiter']%>"
+<%- if @preauthenticated_config['userNameHeader'] -%>
 rundeck.security.authorization.preauthenticated.userNameHeader = "<%= @preauthenticated_config['userNameHeader']%>"
+<%- end -%>
+<%- if @preauthenticated_config['userRolesHeader'] -%>
 rundeck.security.authorization.preauthenticated.userRolesHeader = "<%= @preauthenticated_config['userRolesHeader']%>"
+<%- end -%>
 rundeck.security.authorization.preauthenticated.redirectLogout = "<%= @preauthenticated_config['redirectLogout']%>"
+<%- if @preauthenticated_config['redirectUrl'] -%>
 rundeck.security.authorization.preauthenticated.redirectUrl = "<%= @preauthenticated_config['redirectUrl']%>"
+<%- end -%>
 
 <%- @gui_config.sort.each do |k,v| -%>
 <%= k %> = "<%= v %>"


### PR DESCRIPTION
Pull Request (PR) description

Preauth config will use only the populated values for userNameHeader, userRolesHeader, and redirectUrl.
Replaces PR390, source branch somehow deleted...

This Pull Request (PR) fixes the following issues

Fixes #375