### PR TITLE
Add option storage_encrypt_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ Boolean value if set to true enables security_roles_array.
 
 Array value if you want to have more role in web.xml
 
+##### `storage_encrypt_config`
+
+Hash containing the necessary values to configure a plugin for key storage
+encryption.
+
 ##### `manage_repo`
 
 Whether to manage the bintray YUM/APT repository containing the Rundeck rpm/deb. Defaults to true.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,6 +68,7 @@ class rundeck::config {
   $ssl_port                           = $rundeck::ssl_port
   $ssl_keyfile                        = $rundeck::ssl_keyfile
   $ssl_certfile                       = $rundeck::ssl_certfile
+  $storage_encrypt_config             = $rundeck::storage_encrypt_config
   $truststore                         = $rundeck::truststore
   $truststore_password                = $rundeck::truststore_password
   $user                               = $rundeck::user

--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -33,6 +33,7 @@ class rundeck::config::global::rundeck_config {
   $rdeck_config_template                = $rundeck::config::rdeck_config_template
   $rss_enabled                          = $rundeck::config::rss_enabled
   $security_config                      = $rundeck::config::security_config
+  $storage_encrypt_config               = $rundeck::config::storage_encrypt_config
   $user                                 = $rundeck::config::user
 
   $properties_file = "${properties_dir}/rundeck-config.groovy"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,6 +202,15 @@
 #  $security_roles_array_enabled = hiera('rundeck::config::global::web::security_roles_array_enabled', true),
 #  $security_roles_array         = hiera('rundeck::config::global::web::security_roles_array', []),
 #
+# [*storage_encrypt_config*]
+# Hash containing the necessary values to configure a plugin for
+# key storage encryption. Example:
+# rundeck::config::storage_encrypt_config:
+#   type: 'jasypt-encryption'
+#   path: 'keys'
+#   config.encryptionType: 'basic'
+#   config.password: 'verysecure'
+#
 class rundeck (
   Array[Hash] $acl_policies                                     = $rundeck::params::acl_policies,
   String $acl_template                                          = $rundeck::params::acl_template,
@@ -281,6 +290,7 @@ class rundeck (
   String $file_default_mode                                     = $rundeck::params::file_default_mode,
   Boolean $security_roles_array_enabled                         = $rundeck::params::security_roles_array_enabled,
   Array $security_roles_array                                   = $rundeck::params::security_roles_array,
+  Hash[String,String] $storage_encrypt_config                   = {},
 ) inherits rundeck::params {
 
   validate_rd_policy($acl_policies)

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -123,6 +123,21 @@ describe 'rundeck' do
 
         it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.executionMode = "passive"}) }
       end
+
+      describe "rundeck::config::global::rundeck_config class with key storage encryption on #{os}" do
+        storage_encrypt_config_hash = {
+          'type'                  => 'thetype',
+          'path'                  => '/storagepath',
+          'config.encryptionType' => 'basic',
+          'config.password'       => 'verysecure'
+        }
+        let(:params) { { storage_encrypt_config: storage_encrypt_config_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.type = "thetype"}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.path = "/storagepath"}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.config\.encryptionType = "basic"}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.config\.password = "verysecure"}) }
+      end
     end
   end
 end

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -85,6 +85,12 @@ rundeck.storage.provider."1".removePathPrefix = true
 rundeck.storage.provider."1".type = "db"
 <%- end -%>
 rundeck.storage.provider."1".path = "/"
+<%- if !@storage_encrypt_config.empty? -%>
+
+  <%- @storage_encrypt_config.sort.each do |k,v| -%>
+rundeck.storage.converter."1".<%= k %> = "<%= v %>"
+  <%- end -%>
+<%- end -%>
 
 rundeck.security.authorization.preauthenticated.enabled = "<%= @preauthenticated_config['enabled']%>"
 rundeck.security.authorization.preauthenticated.attributeName = "<%= @preauthenticated_config['attributeName']%>"


### PR DESCRIPTION
#### Pull Request (PR) description

This changeset adds a new option to the module so it's possible to configure a storage encryption plugin. Example:

```yaml
rundeck::config::storage_encrypt_config:
   type: 'jasypt-encryption'
   path: 'keys'
   config.encryptionType: 'basic'
   config.password: 'verysecure'
```

https://docs.rundeck.com/docs/administration/configuration/plugins/bundled-plugins.html#jasypt-encryption-plugin
