### PR TITLE
Make preauthentication based on headers optional

### DIFF
--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -138,6 +138,15 @@ describe 'rundeck' do
         it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.config\.encryptionType = "basic"}) }
         it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.config\.password = "verysecure"}) }
       end
+
+      describe "rundeck::config::global::rundeck_config class without username and roles headers on #{os}" do
+        preauthenticated_config_hash = {
+        }
+        let(:params) { { preauthenticated_config: preauthenticated_config_hash } }
+
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.authorization\.preauthenticated\.userNameHeader.*}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.authorization\.preauthenticated\.userRolesHeader.*}) }
+      end
     end
   end
 end

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -95,8 +95,12 @@ rundeck.storage.converter."1".<%= k %> = "<%= v %>"
 rundeck.security.authorization.preauthenticated.enabled = "<%= @preauthenticated_config['enabled']%>"
 rundeck.security.authorization.preauthenticated.attributeName = "<%= @preauthenticated_config['attributeName']%>"
 rundeck.security.authorization.preauthenticated.delimiter = "<%= @preauthenticated_config['delimiter']%>"
+<%- if @preauthenticated_config.key?('userNameHeader') -%>
 rundeck.security.authorization.preauthenticated.userNameHeader = "<%= @preauthenticated_config['userNameHeader']%>"
+<%- end -%>
+<%- if @preauthenticated_config.key?('userRolesHeader') -%>
 rundeck.security.authorization.preauthenticated.userRolesHeader = "<%= @preauthenticated_config['userRolesHeader']%>"
+<%- end -%>
 rundeck.security.authorization.preauthenticated.redirectLogout = "<%= @preauthenticated_config['redirectLogout']%>"
 rundeck.security.authorization.preauthenticated.redirectUrl = "<%= @preauthenticated_config['redirectUrl']%>"
 


### PR DESCRIPTION
#### Pull Request (PR) description

Users might only want to configure preauthentication using request attributes, without making use of any header. The issue is that in that scenario setting the header-related settings to empty values seems to break things. I think it's probably a good idea to set them only if the relevant keys are present in `preauthenticated_config`.
