### PR TITLE
various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ The installation directory for Rundeck.
 ##### `server_web_context`
 
 Web context path to use, such as "/rundeck". `http://host.domain:port/server_web_context`
+( Use this for Rundeck versions < 3.3 )
+
+##### `server_web_context33`
+
+Web context path to use, such as "/rundeck". `http://host.domain:port/server_web_context`
+( Use this for Rundeck versions >= 3.3 )
+
+##### `server_address`
+
+The listen address for the Rundeck service.
 
 ##### `ssl_enabled`
 
@@ -299,6 +309,10 @@ Whether to manage `user` (and enforce `user_id` if set). Defaults to false.
 ##### `manage_home`
 
 Whether to create the `rundeck_home` directory. Defaults to true.
+
+##### `auth_config`
+
+A dictionary of various auth-related configuration, including the default admin password, ldap, and pam settings.
 
 ##### `keystorage_type`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -60,6 +60,8 @@ class rundeck::config {
   $security_config                    = $rundeck::security_config
   $security_role                      = $rundeck::security_role
   $server_web_context                 = $rundeck::server_web_context
+  $server_web_context33               = $rundeck::server_web_context33
+  $server_address                     = $rundeck::server_address
   $service_logs_dir                   = $rundeck::service_logs_dir
   $service_name                       = $rundeck::service_name
   $session_timeout                    = $rundeck::session_timeout
@@ -212,6 +214,7 @@ class rundeck::config {
   }
 
   create_resources(rundeck::config::project, $projects)
+  create_resources(rundeck::config::plugin, $plugins)
 
   if versioncmp( $package_ensure, '3.0.0' ) < 0 {
     class { 'rundeck::config::global::web':

--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -99,6 +99,7 @@ define rundeck::config::resource_source (
   String $filter_tag                                             = '',
   Stdlib::Port $http_proxy_port                                  = $rundeck::params::default_http_proxy_port,
   Integer $refresh_interval                                      = $rundeck::params::default_refresh_interval,
+  Integer $page_results                                          = $rundeck::params::default_page_results,
   Optional[String] $puppet_enterprise_host                       = undef,
   Optional[Stdlib::Port] $puppet_enterprise_port                 = undef,
   Optional[Stdlib::Absolutepath] $puppet_enterprise_ssl_dir      = undef,
@@ -324,21 +325,27 @@ define rundeck::config::resource_source (
         value   => bool2str($running_only),
         require => File[$properties_file],
       }
-      ini_setting { "${name}::resources.source.${number}.config.endpoint":
-        ensure  => present,
-        path    => $properties_file,
-        section => '',
-        setting => "resources.source.${number}.config.endpoint",
-        value   => $endpoint_url,
-        require => File[$properties_file],
+      # endpoint is an optional field that must be omitted if empty
+      if ($endpoint_url) {
+        ini_setting { "${name}::resources.source.${number}.config.endpoint":
+          ensure  => present,
+          path    => $properties_file,
+          section => '',
+          setting => "resources.source.${number}.config.endpoint",
+          value   => $endpoint_url,
+          require => File[$properties_file],
+        }
       }
-      ini_setting { "${name}::resources.source.${number}.config.assumeRoleArn":
-        ensure  => present,
-        path    => $properties_file,
-        section => '',
-        setting => "resources.source.${number}.config.assumeRoleArn",
-        value   => $assume_role_arn,
-        require => File[$properties_file],
+      # assumeRoleArn is an optional field that must be omitted if empty
+      if ($assume_role_arn) {
+        ini_setting { "${name}::resources.source.${number}.config.assumeRoleArn":
+          ensure  => present,
+          path    => $properties_file,
+          section => '',
+          setting => "resources.source.${number}.config.assumeRoleArn",
+          value   => $assume_role_arn,
+          require => File[$properties_file],
+        }
       }
       ini_setting { "${name}::resources.source.${number}.config.filter":
         ensure  => present,
@@ -362,6 +369,15 @@ define rundeck::config::resource_source (
         section => '',
         setting => "resources.source.${number}.config.refreshInterval",
         value   => $refresh_interval,
+        require => File[$properties_file],
+      }
+      # pageResults is a required field and must be numeric
+      ini_setting { "${name}::resources.source.${number}.config.pageResults":
+        ensure  => present,
+        path    => $properties_file,
+        section => '',
+        setting => "resources.source.${number}.config.pageResults",
+        value   => $page_results,
         require => File[$properties_file],
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,6 +150,13 @@
 # [*server_web_context*]
 #  Web context path to use, such as "/rundeck". http://host.domain:port/server_web_context
 #
+# [*server_web_context33*]
+#  Web context path to use, such as "/rundeck". http://host.domain:port/server_web_context
+#  Syntax for Rundeck 3.3+
+#
+# [*server_address*]
+#  The listen address for the Rundeck service.
+#
 # [*service_logs_dir*]
 #  The path to the directory to store logs.
 #
@@ -249,6 +256,7 @@ class rundeck (
   Boolean $manage_default_api_policy                            = $rundeck::params::manage_default_api_policy,
   Boolean $manage_repo                                          = $rundeck::params::manage_repo,
   String $package_ensure                                        = $rundeck::params::package_ensure,
+  Hash $plugins                                                 = $rundeck::params::plugins,
   Hash $preauthenticated_config                                 = $rundeck::params::preauthenticated_config,
   Hash $projects                                                = $rundeck::params::projects,
   String $projects_description                                  = $rundeck::params::projects_default_desc,
@@ -271,6 +279,8 @@ class rundeck (
   Hash $security_config                                         = $rundeck::params::security_config,
   String $security_role                                         = $rundeck::params::security_role,
   Optional[String] $server_web_context                          = undef,
+  Optional[String] $server_web_context33                        = undef,
+  Optional[String] $server_address                              = undef,
   Optional[String] $service_config                              = undef,
   Stdlib::Absolutepath $service_logs_dir                        = $rundeck::params::service_logs_dir,
   String $service_name                                          = $rundeck::params::service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -227,6 +227,7 @@ class rundeck::params {
     'apiCookieAccess'      => true,
   }
 
+  $plugins = {}
   $projects = {}
   $projects_default_org = ''
   $projects_default_desc = ''
@@ -243,6 +244,7 @@ class rundeck::params {
   $default_resource_dir = '/'
   $default_http_proxy_port = 80
   $default_refresh_interval = 30
+  $default_page_results = 100
 
   $script_args_quoted = true
   $script_interpreter = '/bin/bash'

--- a/templates/aclpolicy.erb
+++ b/templates/aclpolicy.erb
@@ -21,6 +21,7 @@ for:
   <%- end -%>
   <%- end -%>
 <%- end -%>
+<%- if policy.key?('by') -%>
 by:
 <%- policy['by'].each do |by| -%>
 <%-   if !by['group'].nil? && by['group'] != :undef -%>
@@ -35,6 +36,24 @@ by:
     - '<%= username %>'
   <%- end -%>
 <%-   end -%>
+<%- end -%>
+<%- end -%>
+<%- if policy.key?('notBy') -%>
+notBy:
+<%- policy['notBy'].each do |notBy| -%>
+<%-   if !notBy['group'].nil? && notBy['group'] != :undef -%>
+  group:
+  <%- notBy['group'].each do |group| -%>
+    - '<%= group %>'
+  <%- end -%>
+<%-   end -%>
+<%-   if !notBy['username'].nil? && notBy['username'] != :undef -%>
+  username:
+  <%- notBy['username'].each do |username| -%>
+    - '<%= username %>'
+  <%- end -%>
+<%-   end -%>
+<%- end -%>
 <%- end -%>
 <%- if index != (@acl_policies.length-1) -%>
 

--- a/templates/profile_overrides.erb
+++ b/templates/profile_overrides.erb
@@ -11,8 +11,16 @@ RDECK_JVM_SETTINGS="<%= @jvm_args %>"
 RDECK_JVM_SETTINGS="$RDECK_JVM_SETTINGS -Dserver.web.context=<%= @server_web_context %>"
 <%- end -%>
 
+<%- if @server_web_context33 -%>
+RDECK_JVM_SETTINGS="$RDECK_JVM_SETTINGS -Dserver.servlet.context-path=<%= @server_web_context33 %>"
+<%- end -%>
+
 <%- if !(@kerberos_realms.empty?) -%>
 RDECK_JVM_SETTINGS="$RDECK_JVM_SETTINGS -Djava.security.krb5.conf=$RDECK_CONFIG/krb5.conf"
+<%- end -%>
+
+<%- if @server_address -%>
+RDECK_JVM_SETTINGS="$RDECK_JVM_SETTINGS -Dserver.address=<%= @server_address %>"
 <%- end -%>
 
 <% if @java_home %>


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a few things I encountered on my project setting up Rundeck 3.3 with this module:
- adds support for the new Rundeck server web context parameter (for Rundeck versions 3.3 and above)
- adds a parameter called "server_address" to configure the listen address of the rundeck service (e.g. 127.0.0.1)
- adds documentation for the auth_config parameter to the README
- enables create_resources for rundeck plugins
- fixes a few parameters in the resource_source defined type
  - endpoint parameter is optional and cannot be present if no value was supplied
  - assume role arn parameter is optional and cannot be present if no value was supplied
  - pageresults is required, so must have a default value if no value was supplied
- adds support for the "notBy" syntax in Rundeck acl policies
(https://docs.rundeck.com/docs/manual/document-format-reference/aclpolicy-v10.html#notby)