### PR TITLE
(#459) prevent colon added in realm.properties when auth_users hash is empty

### DIFF
--- a/templates/realm.properties.erb
+++ b/templates/realm.properties.erb
@@ -26,15 +26,19 @@
 <%- if @auth_config['file']['auth_users'] -%>
   <%- if @auth_config['file']['auth_users'].kind_of?(Array) -%>
     <%- @auth_config['file']['auth_users'].each do |x| -%>
-<%= x['username'] -%>:<%= x.fetch('password', '-') -%>
-      <%- if x['roles'] -%>
-        <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
+      <%- if x['username'] and x['password'] -%>
+        <%= x['username'] -%>:<%= x.fetch('password', '-') -%>
+        <%- if x['roles'] -%>
+          <%- x['roles'].each do |v| -%>,<%= v -%><%- end %>
+        <%- end -%>
       <%- end -%>
     <%- end -%>
   <%- else -%>
-<%= @auth_config['file']['auth_users']['username'] -%>:<%= @auth_config['file']['auth_users']['password'] -%>
-    <%- if @auth_config['file']['auth_users']['roles'] -%>
-      <%- @auth_config['file']['auth_users']['roles'].each do |v| -%>,<%= v -%><%- end %>
+    <%- if @auth_config['file']['auth_users']['username'] and @auth_config['file']['auth_users']['password'] -%>
+      <%= @auth_config['file']['auth_users']['username'] -%>:<%= @auth_config['file']['auth_users']['password'] -%>
+      <%- if @auth_config['file']['auth_users']['roles'] -%>
+        <%- @auth_config['file']['auth_users']['roles'].each do |v| -%>,<%= v -%><%- end %>
+      <%- end -%>
     <%- end -%>
   <%- end -%>
 <%- end %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This changeset fix issue when @auth_config['file']['auth_users'] hash is empty, a colon added in realm.properties file when it shouldn't.
Fix also wrong indentation.

#### This Pull Request (PR) fixes the following issues
Fixes #459 