### PR TITLE
Add possibility to override profile template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,6 +55,7 @@ class rundeck::config {
   $rdeck_home                         = $rundeck::rdeck_home
   $manage_home                        = $rundeck::manage_home
   $rdeck_profile_template             = $rundeck::rdeck_profile_template
+  $rdeck_override_template            = $rundeck::rdeck_override_template
   $realm_template                     = $rundeck::realm_template
   $rss_enabled                        = $rundeck::rss_enabled
   $security_config                    = $rundeck::security_config
@@ -191,8 +192,10 @@ class rundeck::config {
     }
   }
 
-  file { "${overrides_dir}/${service_name}":
-    content => template('rundeck/profile_overrides.erb'),
+  if ($rdeck_override_template) {
+    file { "${overrides_dir}/${service_name}":
+      content => template($rdeck_override_template),
+    }
   }
 
   contain rundeck::config::global::framework

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,6 +138,9 @@
 # [*rdeck_profile_template*]
 #  Allows you to use your own profile template instead of the default from the package maintainer
 #
+# [*rdeck_override_template*]
+#  Allows you to use your own override template instead of the default from the package maintainer
+#
 # [*rss_enabled*]
 #  Boolean value if set to true enables RSS feeds that are public (non-authenticated)
 #
@@ -261,6 +264,7 @@ class rundeck (
   Stdlib::Absolutepath $rdeck_home                              = $rundeck::params::rdeck_home,
   Boolean $manage_home                                          = $rundeck::params::manage_home,
   Optional[String] $rdeck_profile_template                      = undef,
+  String $rdeck_override_template                               = 'rundeck/profile_overrides.erb',
   String $realm_template                                        = $rundeck::params::realm_template,
   Stdlib::HTTPUrl $repo_yum_source                              = $rundeck::params::repo_yum_source,
   String $repo_yum_gpgkey                                       = $rundeck::params::repo_yum_gpgkey,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -62,6 +62,17 @@ describe 'rundeck' do
         it { is_expected.to contain_file('/etc/rundeck/profile') }
       end
 
+      describe 'rundeck::config with rdeck_override_template set' do
+        template = 'rundeck/../spec/fixtures/files/override.template'
+        let(:params) { { rdeck_override_template: template }}
+
+        it { is_expected.to contain_file(overrides)}
+        it 'uses the content for the profile overrides template' do
+          content = catalogue.resource('file', overrides)[:content]
+          expect(content).to include('test override template')
+        end
+      end
+
       describe 'rundeck::config with jvm_args set' do
         jvm_args = '-Dserver.http.port=8008 -Xms2048m -Xmx2048m -server'
         let(:params) { { jvm_args: jvm_args } }

--- a/spec/fixtures/files/override.template
+++ b/spec/fixtures/files/override.template
@@ -1,0 +1,1 @@
+test override template


### PR DESCRIPTION

#### Pull Request (PR) description
Allows the user to specify a different override template as the one that comes with the module.

In some situations, it's just enough to set parameters in the override file that goes into /etc/sysconfig/rundeckd or /etc/default/rundeck  to configure rundeck, leaving the profile (/etc/rundeck/profile) untouched and managed by the packager.

This PR just provides the possibility to specify it and it defaults to the previous behavior for any user of this module.

Signed-off-by: Jose Castro Leon <jose.castro.leon@cern.ch>