### PR TITLE
Fix rubocop issues with override_template MR

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -64,9 +64,9 @@ describe 'rundeck' do
 
       describe 'rundeck::config with rdeck_override_template set' do
         template = 'rundeck/../spec/fixtures/files/override.template'
-        let(:params) { { rdeck_override_template: template }}
+        let(:params) { { rdeck_override_template: template } }
 
-        it { is_expected.to contain_file(overrides)}
+        it { is_expected.to contain_file(overrides) }
         it 'uses the content for the profile overrides template' do
           content = catalogue.resource('file', overrides)[:content]
           expect(content).to include('test override template')


### PR DESCRIPTION
Signed-off-by: Jose Castro Leon <jose.castro.leon@cern.ch>

#### Pull Request (PR) description

In the MR regarding the override_template parameter, it seems that I introduced an issue that our local rubocop CI founds.
This is just to avoid such issue and prevent CI jobs to fail.

#### This Pull Request (PR) fixes the following issues

RuboCop failed!
Running RuboCop...
Inspecting 29 files
...C.........................
Offenses:
spec/classes/config_spec.rb:67:61: C: Layout/SpaceInsideBlockBraces: Space missing inside }.
        let(:params) { { rdeck_override_template: template }}
                                                            ^
spec/classes/config_spec.rb:69:52: C: Layout/SpaceInsideBlockBraces: Space missing inside }.
        it { is_expected.to contain_file(overrides)}
                                                   ^
29 files inspected, 2 offenses detected
