### PR TITLE
puppetlabs/apt: Allow 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.4.1 < 5.0.0"
+      "version_requirement": ">= 1.4.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/java_ks",

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 7.0.0"
+      "version_requirement": ">= 4.25.0 < 8.0.0"
     },
     {
       "name": "pltraining/dirtree",

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
     },
     {
       "name": "puppetlabs/java_ks",
-      "version_requirement": ">= 1.3.1 < 4.0.0"
+      "version_requirement": ">= 1.3.1 < 5.0.0"
     },
     {
       "name": "puppet/archive",

--- a/metadata.json
+++ b/metadata.json
@@ -56,12 +56,12 @@
       "version_requirement": ">= 1.4.1 < 5.0.0"
     },
     {
-      "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 < 5.0.0"
-    },
-    {
       "name": "puppetlabs/java_ks",
       "version_requirement": ">= 1.3.1 < 4.0.0"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 1.0.0 < 6.0.0"
     }
   ],
   "requirements": [

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,5 +2,5 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
   install_module_from_forge_on(host, 'puppetlabs-java', '>= 2.1.0 < 8.0.0')
-  install_module_from_forge_on(host, 'puppetlabs-apt', '>= 4.1.0 < 8.0.0')
+  install_module_from_forge_on(host, 'puppetlabs-apt', '>= 4.1.0 < 9.0.0')
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,6 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
-  install_module_from_forge_on(host, 'puppetlabs-java', '>= 2.1.0 < 7.0.0')
+  install_module_from_forge_on(host, 'puppetlabs-java', '>= 2.1.0 < 8.0.0')
   install_module_from_forge_on(host, 'puppetlabs-apt', '>= 4.1.0 < 8.0.0')
 end


### PR DESCRIPTION
also contains:
* https://github.com/voxpupuli/puppet-rundeck/pull/464
* https://github.com/voxpupuli/puppet-rundeck/pull/463
* https://github.com/voxpupuli/puppet-rundeck/pull/465
* https://github.com/voxpupuli/puppet-rundeck/pull/466
* https://github.com/voxpupuli/puppet-rundeck/pull/467