### PR TITLE
Allow to configure log4j2 required for Rundeck >= 3.3

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,7 @@ class rundeck::config {
   $key_storage_type                   = $rundeck::key_storage_type
   $keystore                           = $rundeck::keystore
   $keystore_password                  = $rundeck::keystore_password
+  $log4j_version                      = $rundeck::log4j_version
   $log_properties_template            = $rundeck::log_properties_template
   $mail_config                        = $rundeck::mail_config
   $manage_default_admin_policy        = $rundeck::manage_default_admin_policy
@@ -160,9 +161,23 @@ class rundeck::config {
     require => File[$properties_dir],
   }
 
-  file { "${properties_dir}/log4j.properties":
-    content => template($log_properties_template),
-    require => File[$properties_dir],
+  case $log4j_version {
+    '2': {
+      file { "${properties_dir}/log4j2.properties":
+        content => template($log_properties_template),
+        require => File[$properties_dir],
+      }
+      file { "${properties_dir}/log4j.properties":
+        ensure  => absent,
+        require => File[$properties_dir],
+      }
+    }
+    default: {
+      file { "${properties_dir}/log4j.properties":
+        content => template($log_properties_template),
+        require => File[$properties_dir],
+      }
+    }
   }
 
   if $manage_default_admin_policy {

--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -22,6 +22,7 @@ class rundeck::config::global::rundeck_config {
   $group                                = $rundeck::config::group
   $gui_config                           = $rundeck::config::gui_config
   $key_storage_type                     = $rundeck::config::key_storage_type
+  $log4j_version                        = $rundeck::config::log4j_version
   $mail_config                          = $rundeck::config::mail_config
   $preauthenticated_config              = $rundeck::config::preauthenticated_config
   $projects_storage_type                = $rundeck::config::projects_storage_type

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -247,6 +247,7 @@ class rundeck (
   Optional[String[1]] $vault_keystorage_approle_authmount       = undef,
   Optional[String[1]] $vault_keystorage_authbackend             = undef,
   String $keystore_password                                     = $rundeck::params::keystore_password,
+  Enum['1', '2'] $log4j_version                                 = $rundeck::params::log4j_version,
   String $log_properties_template                               = $rundeck::params::log_properties_template,
   Hash $mail_config                                             = $rundeck::params::mail_config,
   Boolean $sshkey_manage                                        = $rundeck::params::sshkey_manage,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,7 @@ class rundeck::params {
   $auth_users = {}
   $auth_template = 'rundeck/jaas-auth.conf.erb'
 
+  $log4j_version = '1'
   $log_properties_template = 'rundeck/log4j.properties.erb'
 
   $acl_template = 'rundeck/aclpolicy.erb'

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -124,6 +124,12 @@ describe 'rundeck' do
         it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.executionMode = "passive"}) }
       end
 
+      describe "rundeck::config::global::rundeck_config class with log4j_version '2' on #{os}" do
+        let(:params) { { log4j_version: '2' } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{log4j\.configurationFile = "/etc/rundeck/log4j2.properties"}) }
+      end
+
       describe "rundeck::config::global::rundeck_config class with key storage encryption on #{os}" do
         storage_encrypt_config_hash = {
           'type'                  => 'thetype',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -33,7 +33,7 @@ describe 'rundeck' do
         end
 
         it { is_expected.to contain_file('/etc/rundeck/log4j.properties') }
-        it 'generates valid content for log4j.propertiess' do
+        it 'generates valid content for log4j.properties' do
           content = catalogue.resource('file', '/etc/rundeck/log4j.properties')[:content]
           expect(content).to include('log4j.appender.server-logger.file=/var/log/rundeck/rundeck.log')
         end
@@ -53,6 +53,21 @@ describe 'rundeck' do
 
         it { is_expected.to contain_rundeck__config__aclpolicyfile('admin') }
         it { is_expected.to contain_rundeck__config__aclpolicyfile('apitoken') }
+      end
+
+      describe 'rundeck::config with log4j2' do
+        let(:params) do
+          {
+            log4j_version: '2',
+            log_properties_template: 'rundeck/log4j2.properties.erb'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/rundeck/log4j2.properties') }
+        it 'generates valid content for log4j2.properties' do
+          content = catalogue.resource('file', '/etc/rundeck/log4j2.properties')[:content]
+          expect(content).to include('appender.rundeck.fileName = ${baseDir}/rundeck.log')
+        end
       end
 
       describe 'rundeck::config with rdeck_profile_template set' do

--- a/templates/log4j2.properties.erb
+++ b/templates/log4j2.properties.erb
@@ -1,0 +1,258 @@
+
+name = Rundeck Logging Configuration
+
+property.baseDir = <%= @service_logs_dir %>
+property.classLength = 2
+property.noConsoleNoAnsi = true
+property.prefix = [%style{%d{ISO8601}}{dim, noConsoleNoAnsi=${noConsoleNoAnsi}}] %highlight{%-5p}{noConsoleNoAnsi=${noConsoleNoAnsi}} %style{%c{${classLength}}}{cyan,noConsoleNoAnsi=${noConsoleNoAnsi}}
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = ${prefix} - %m%n
+
+appender.rundeck.type = RollingFile
+appender.rundeck.name = rundeck
+appender.rundeck.fileName = ${baseDir}/rundeck.log
+appender.rundeck.append = true
+appender.rundeck.bufferedIO = true
+appender.rundeck.filePattern = ${baseDir}/rundeck.log.%d{yyyy-MM-dd}.gz
+appender.rundeck.layout.type = PatternLayout
+appender.rundeck.layout.pattern = ${prefix} [%t] - %m%n
+appender.rundeck.policies.type = Policies
+appender.rundeck.policies.time.type = TimeBasedTriggeringPolicy
+appender.rundeck.policies.time.interval = 1
+
+appender.audit.type = RollingFile
+appender.audit.name = audit
+appender.audit.fileName = ${baseDir}/rundeck.audit.log
+appender.audit.append = true
+appender.audit.bufferedIO = true
+appender.audit.filePattern = ${baseDir}/rundeck.audit.log.%d{yyyy-MM-dd}.gz
+appender.audit.layout.type = PatternLayout
+appender.audit.layout.pattern = ${prefix} - %m%n
+appender.audit.policies.type = Policies
+appender.audit.policies.time.type = TimeBasedTriggeringPolicy
+appender.audit.policies.time.interval = 1
+
+appender.options.type = RollingFile
+appender.options.name = options
+appender.options.fileName = ${baseDir}/rundeck.options.log
+appender.options.append = true
+appender.options.bufferedIO = true
+appender.options.filePattern = ${baseDir}/rundeck.options.log.%d{yyyy-MM-dd}.gz
+appender.options.layout.type = PatternLayout
+appender.options.layout.pattern = ${prefix} %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
+appender.options.policies.type = Policies
+appender.options.policies.time.type = TimeBasedTriggeringPolicy
+appender.options.policies.time.interval = 1
+
+appender.storage.type = RollingFile
+appender.storage.name = storage
+appender.storage.fileName = ${baseDir}/rundeck.storage.log
+appender.storage.append = true
+appender.storage.bufferedIO = true
+appender.storage.filePattern = ${baseDir}/rundeck.storage.log.%d{yyyy-MM-dd}.gz
+appender.storage.layout.type = PatternLayout
+appender.storage.layout.pattern = ${prefix} %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
+appender.storage.policies.type = Policies
+appender.storage.policies.time.type = TimeBasedTriggeringPolicy
+appender.storage.policies.time.interval = 1
+
+appender.jobchanges.type = RollingFile
+appender.jobchanges.name = jobchanges
+appender.jobchanges.fileName = ${baseDir}/rundeck.jobs.log
+appender.jobchanges.append = true
+appender.jobchanges.bufferedIO = true
+appender.jobchanges.filePattern = ${baseDir}/rundeck.jobs.log.%d{yyyy-MM-dd}.gz
+appender.jobchanges.layout.type = PatternLayout
+appender.jobchanges.layout.pattern = ${prefix} %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
+appender.jobchanges.policies.type = Policies
+appender.jobchanges.policies.time.type = TimeBasedTriggeringPolicy
+appender.jobchanges.policies.time.interval = 1
+
+appender.execevents.type = RollingFile
+appender.execevents.name = execevents
+appender.execevents.fileName = ${baseDir}/rundeck.executions.log
+appender.execevents.append = true
+appender.execevents.bufferedIO = true
+appender.execevents.filePattern = ${baseDir}/rundeck.executions.log.%d{yyyy-MM-dd}.gz
+appender.execevents.layout.type = PatternLayout
+appender.execevents.layout.pattern = ${prefix} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} \"%X{groupPath}/%X{jobName}  %X{argString}\"[%X{uuid}] %n
+appender.execevents.policies.type = Policies
+appender.execevents.policies.time.type = TimeBasedTriggeringPolicy
+appender.execevents.policies.time.interval = 1
+
+appender.apirequests.type = RollingFile
+appender.apirequests.name = apirequests
+appender.apirequests.fileName = ${baseDir}/rundeck.api.log
+appender.apirequests.append = true
+appender.apirequests.bufferedIO = true
+appender.apirequests.filePattern = ${baseDir}/rundeck.api.log.%d{yyyy-MM-dd}.gz
+appender.apirequests.layout.type = PatternLayout
+appender.apirequests.layout.pattern = ${prefix} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} (%X{userAgent})%n
+appender.apirequests.policies.type = Policies
+appender.apirequests.policies.time.type = TimeBasedTriggeringPolicy
+appender.apirequests.policies.time.interval = 1
+
+appender.access.type = RollingFile
+appender.access.name = access
+appender.access.fileName = ${baseDir}/rundeck.access.log
+appender.access.append = true
+appender.access.bufferedIO = true
+appender.access.filePattern = ${baseDir}/rundeck.access.log.%d{yyyy-MM-dd}.gz
+appender.access.layout.type = PatternLayout
+appender.access.layout.pattern = ${prefix} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
+appender.access.policies.type = Policies
+appender.access.policies.time.type = TimeBasedTriggeringPolicy
+appender.access.policies.time.interval = 1
+
+appender.project.type = RollingFile
+appender.project.name = project
+appender.project.fileName = ${baseDir}/rundeck.project.log
+appender.project.append = true
+appender.project.bufferedIO = true
+appender.project.filePattern = ${baseDir}/rundeck.project.log.%d{yyyy-MM-dd}.gz
+appender.project.layout.type = PatternLayout
+appender.project.layout.pattern = ${prefix} - %m%n
+appender.project.policies.type = Policies
+appender.project.policies.time.type = TimeBasedTriggeringPolicy
+appender.project.policies.time.interval = 1
+
+appender.cleanup.type = RollingFile
+appender.cleanup.name = cleanup
+appender.cleanup.fileName = ${baseDir}/rundeck.cleanup.log
+appender.cleanup.append = true
+appender.cleanup.bufferedIO = true
+appender.cleanup.filePattern = ${baseDir}/rundeck.cleanup.log.%d{yyyy-MM-dd}.gz
+appender.cleanup.layout.type = PatternLayout
+appender.cleanup.layout.pattern = ${prefix} - %m%n
+appender.cleanup.policies.type = Policies
+appender.cleanup.policies.time.type = TimeBasedTriggeringPolicy
+appender.cleanup.policies.time.interval = 1
+
+appender.webhooks.type = RollingFile
+appender.webhooks.name = webhooks
+appender.webhooks.fileName = ${baseDir}/rundeck.webhooks.log
+appender.webhooks.append = true
+appender.webhooks.bufferedIO = true
+appender.webhooks.filePattern = ${baseDir}/rundeck.webhooks.log.%d{yyyy-MM-dd}.gz
+appender.webhooks.layout.type = PatternLayout
+appender.webhooks.layout.pattern = ${prefix} - %m%n
+appender.webhooks.policies.type = Policies
+appender.webhooks.policies.time.type = TimeBasedTriggeringPolicy
+appender.webhooks.policies.time.interval = 1
+
+rootLogger.level = warn
+rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.rundeck.ref = rundeck
+
+logger.interceptors.name = rundeck.interceptors
+logger.interceptors.level = info
+logger.interceptors.additivity = false
+logger.interceptors.appenderRef.stdout.ref = STDOUT
+
+logger.rundeckapp.name = rundeckapp
+logger.rundeckapp.level = info
+logger.rundeckapp.additivity = false
+logger.rundeckapp.appenderRef.stdout.ref = STDOUT
+
+logger.bootstrap.name = rundeckapp.BootStrap
+logger.bootstrap.level = info
+logger.bootstrap.additivity = false
+logger.bootstrap.appenderRef.stdout.ref = STDOUT
+
+logger.grails.name = grails
+logger.grails.level = warn
+logger.grails.additivity = false
+logger.grails.appenderRef.stdout.ref = STDOUT
+
+logger.grails_env.name = grails.util.Environment
+logger.grails_env.level = error
+logger.grails_env.additivity = false
+logger.grails_env.appenderRef.stdout.ref = STDOUT
+
+logger.prjmanager.name = grails.app.services.rundeck.services.ProjectManagerService
+logger.prjmanager.level = info
+logger.prjmanager.additivity = false
+logger.prjmanager.appenderRef.stdout.ref = STDOUT
+
+logger.authorization.name = com.dtolabs.rundeck.core.authorization
+logger.authorization.level = <%= @rd_auditlevel.downcase %>
+logger.authorization.additivity = false
+logger.authorization.appenderRef.stdout.ref = audit
+
+logger.options.name = com.dtolabs.rundeck.remoteservice.http.options
+logger.options.level = info
+logger.options.additivity = false
+logger.options.appenderRef.stdout.ref = options
+
+logger.jobchanges.name = com.dtolabs.rundeck.data.jobs.changes
+logger.jobchanges.level = info
+logger.jobchanges.additivity = false
+logger.jobchanges.appenderRef.stdout.ref = jobchanges
+
+logger.execevents.name = org.rundeck.execution.status
+logger.execevents.level = info
+logger.execevents.additivity = false
+logger.execevents.appenderRef.stdout.ref = execevents
+
+logger.apirequests.name = org.rundeck.api.requests
+logger.apirequests.level = info
+logger.apirequests.additivity = false
+logger.apirequests.appenderRef.stdout.ref = apirequests
+
+logger.access.name = org.rundeck.web.requests
+logger.access.level = info
+logger.access.additivity = false
+logger.access.appenderRef.access.ref = access
+
+logger.project.name = org.rundeck.project.events
+logger.project.level = info
+logger.project.additivity = false
+logger.project.appenderRef.stdout.ref = project
+
+logger.storage.name = org.rundeck.storage.events
+logger.storage.level = info
+logger.storage.additivity = false
+logger.storage.appenderRef.storage.ref = storage
+
+logger.webhook_events.name = org.rundeck.webhook.events
+logger.webhook_events.level = info
+logger.webhook_events.additivity = false
+logger.webhook_events.appenderRef.webhooks.ref = webhooks
+
+logger.webhook_plugins.name = org.rundeck.plugin.webhook
+logger.webhook_plugins.level = debug
+logger.webhook_plugins.additivity = false
+logger.webhook_plugins.appenderRef.webhooks.ref = webhooks
+
+logger.cleanup.name = rundeck.quartzjobs.ExecutionsCleanUp
+logger.cleanup.level = debug
+logger.cleanup.additivity = false
+logger.cleanup.appenderRef.cleanup.ref = cleanup
+
+logger.jetty.name = org.mortbay.log
+logger.jetty.level = warn
+logger.jetty.additivity = false
+logger.jetty.appenderRef.stdout.ref = STDOUT
+
+logger.hibernate.name = org.hibernate.orm.deprecation
+logger.hibernate.level = error
+logger.hibernate.additivity = false
+logger.hibernate.appenderRef.stdout.ref = STDOUT
+
+logger.rundeck_jaas.name = com.dtolabs.rundeck.jetty.jaas
+logger.rundeck_jaas.level = debug
+logger.rundeck_jaas.additivity = false
+logger.rundeck_jaas.appenderRef.stdout.ref = STDOUT
+
+logger.spring_security.name = grails.plugin.springsecurity.web.authentication.GrailsUsernamePasswordAuthenticationFilter
+logger.spring_security.level = debug
+logger.spring_security.additivity = false
+logger.spring_security.appenderRef.stdout.ref = STDOUT
+
+logger.jaas.name = org.rundeck.jaas
+logger.jaas.level = debug
+logger.jaas.additivity = false
+logger.jaas.appenderRef.stdout.ref = STDOUT

--- a/templates/rundeck-config.erb
+++ b/templates/rundeck-config.erb
@@ -1,7 +1,11 @@
 loglevel.default = "<%= @rd_loglevel %>"
 rdeck.base = "<%= @rdeck_base %>"
 rss.enabled = "<%= @rss_enabled %>"
+<%- if @log4j_version == '2'-%>
+log4j.configurationFile = "<%= @properties_dir %>/log4j2.properties"
+<%- else -%>
 rundeck.log4j.config.file = "<%= @properties_dir %>/log4j.properties"
+<%- end -%>
 
 <%- if @security_config.key?('useHMacRequestTokens') -%>
 rundeck.security.useHMacRequestTokens = <%= @security_config['useHMacRequestTokens'] %>


### PR DESCRIPTION
The change of the logging configuration for rundeck towards log4j2 is
required on Rundeck versions from 3.3.0 onwards. This PR allows to
it by using an extra attribute. It also takes care of purging the previous
configuration file to allow the transition.

Signed-off-by: Jose Castro Leon <jose.castro.leon@cern.ch>