### PR TITLE
Add sensitive for rundeck-config.groovy

### DIFF
--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -51,7 +51,7 @@ class rundeck::config::global::rundeck_config {
   }
   file { $properties_file:
     ensure  => file,
-    content => template($rdeck_config_template),
+    content => Sensitive(template($rdeck_config_template)),
     owner   => $user,
     group   => $group,
     mode    => '0640',

--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -32,9 +32,6 @@
 # [*project_name*]
 #   The name of the project for which this resource in intended to be a part.
 #
-# [*projects_dir*]
-#   The directory where rundeck is configured to store project information.
-#
 # [*refresh_interval*]
 #   How often the data will be updated.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,9 +118,6 @@
 # [*projects_storage_type*]
 #  The storage type for any projects. Must be 'filesystem' or 'db'
 #
-# [*properties_dir*]
-#  The path to the configuration directory where the properties file are stored.
-#
 # [*quartz_job_threadcount*]
 #  The maximum number of threads used by Rundeck for concurrent jobs by default is set to 10.
 #
@@ -129,9 +126,6 @@
 #
 # [*rd_auditlevel*]
 #  The log4j logging level to be set for the Rundeck application.
-#
-# [*rdeck_base*]
-#  The installation directory for rundeck.
 #
 # [*rdeck_config_template*]
 #  Allows you to override the rundeck-config template

--- a/spec/classes/config/global/gui_config_spec.rb
+++ b/spec/classes/config/global/gui_config_spec.rb
@@ -20,10 +20,10 @@ describe 'rundeck' do
       # content and meta data for passwords
       it 'generates gui_config content for rundeck-config.groovy' do
         is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').
-          with_content(%r{rundeck.gui.title = "Test title"}).
-          with_content(%r{rundeck.gui.brand.html = "<b>App</b>"}).
-          with_content(%r{rundeck.gui.logo = "test-logo.png"}).
-          with_content(%r{rundeck.gui.login.welcome = "Weclome to Rundeck"})
+          with_content(sensitive(%r{rundeck.gui.title = "Test title"})).
+          with_content(sensitive(%r{rundeck.gui.brand.html = "<b>App</b>"})).
+          with_content(sensitive(%r{rundeck.gui.logo = "test-logo.png"})).
+          with_content(sensitive(%r{rundeck.gui.login.welcome = "Weclome to Rundeck"}))
       end
     end
   end

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -16,7 +16,7 @@ describe 'rundeck' do
         }
         let(:params) { { security_config: security_hash } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.useHMacRequestTokens = #{value}}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.useHMacRequestTokens = #{value}})) }
       end
 
       describe "rundeck::config::global::rundeck_config class with use api cookie access parameter on #{os}" do
@@ -26,7 +26,7 @@ describe 'rundeck' do
         }
         let(:params) { { security_config: security_hash } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.apiCookieAccess\.enabled = #{value}}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.apiCookieAccess\.enabled = #{value}})) }
       end
 
       describe "rundeck::config::global::rundeck_config class with api tokens duration parameter on #{os}" do
@@ -36,7 +36,7 @@ describe 'rundeck' do
         }
         let(:params) { { security_config: security_hash } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.api\.tokens\.duration\.max = "#{duration}"}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.api\.tokens\.duration\.max = "#{duration}"})) }
       end
 
       describe "rundeck::config::global::rundeck_config class with csrf referrer filter method parameter on #{os}" do
@@ -46,7 +46,7 @@ describe 'rundeck' do
         }
         let(:params) { { security_config: security_hash } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.filterMethod = #{value}}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.csrf\.referer\.filterMethod = #{value}})) }
       end
 
       describe "rundeck::config::global::rundeck_config class with csrf referrer require https parameter on #{os}" do
@@ -56,7 +56,7 @@ describe 'rundeck' do
         }
         let(:params) { { security_config: security_hash } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.requireHttps = #{value}}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.csrf\.referer\.requireHttps = #{value}})) }
       end
 
       describe "rundeck::config::global::rundeck_config class with no security parameters on #{os}" do
@@ -66,12 +66,12 @@ describe 'rundeck' do
         security_hash = {}
         let(:params) { { security_config: security_hash } }
 
-        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.useHMacRequestTokens = #{bool_value}}) }
-        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.apiCookieAccess\.enabled = #{bool_value}}) }
-        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.api\.tokens\.duration\.max = "#{duration}"}) }
-        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.filterMethod = #{filter_method_parameter}}) }
-        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.allowApi = #{bool_value}}) }
-        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.security\.csrf\.referer\.requireHttps = #{bool_value}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.useHMacRequestTokens = #{bool_value}})) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.apiCookieAccess\.enabled = #{bool_value}})) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.api\.tokens\.duration\.max = "#{duration}"})) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.csrf\.referer\.filterMethod = #{filter_method_parameter}})) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.csrf\.referer\.allowApi = #{bool_value}})) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.security\.csrf\.referer\.requireHttps = #{bool_value}})) }
       end
 
       describe "rundeck::config::global::rundeck_config class without any parameters on #{os}" do
@@ -111,19 +111,19 @@ describe 'rundeck' do
 
         CONFIG
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with('content' => default_config) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with('content' => sensitive(default_config)) }
       end
 
       describe "rundeck::config::global::rundeck_config class with execution mode parameter 'active' on #{os}" do
         let(:params) { { execution_mode: 'active' } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.executionMode = "active"}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.executionMode = "active"})) }
       end
 
       describe "rundeck::config::global::rundeck_config class with execution mode parameter 'passive' on #{os}" do
         let(:params) { { execution_mode: 'passive' } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.executionMode = "passive"}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.executionMode = "passive"})) }
       end
 
       describe "rundeck::config::global::rundeck_config class with key storage encryption on #{os}" do
@@ -135,10 +135,10 @@ describe 'rundeck' do
         }
         let(:params) { { storage_encrypt_config: storage_encrypt_config_hash } }
 
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.type = "thetype"}) }
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.path = "/storagepath"}) }
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.config\.encryptionType = "basic"}) }
-        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(%r{rundeck\.storage\.converter\."1"\.config\.password = "verysecure"}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.storage\.converter\."1"\.type = "thetype"})) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.storage\.converter\."1"\.path = "/storagepath"})) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.storage\.converter\."1"\.config\.encryptionType = "basic"})) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with_content(sensitive(%r{rundeck\.storage\.converter\."1"\.config\.password = "verysecure"})) }
       end
     end
   end

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,1 +1,2 @@
+# Log levels
 type Rundeck::Loglevel = Enum['ALL', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'OFF', 'TRACE', 'WARN']

--- a/types/sourcetype.pp
+++ b/types/sourcetype.pp
@@ -1,1 +1,2 @@
+# Source types
 type Rundeck::Sourcetype = Enum['file', 'directory', 'url', 'script', 'aws-ec2', 'puppet-enterprise']


### PR DESCRIPTION
Pull Request (PR) description
- This PR fixes that credentials would be shown in puppet log if they change
- This PR contains some minor corrections
    - [warn]: The @param tag for parameter 'properties_dir' has no matching parameter at manifests/init.pp:224.
    - [warn]: The @param tag for parameter 'rdeck_base' has no matching parameter at manifests/init.pp:224.
    - [warn]: The @param tag for parameter 'projects_dir' has no matching parameter at manifests/config/resource_source.pp:80.
    - [warn]: Missing documentation for Puppet type alias 'Rundeck::Loglevel' at types/loglevel.pp:1.
    - [warn]: Missing documentation for Puppet type alias 'Rundeck::Sourcetype' at types/sourcetype.pp:1.

This Pull Request (PR) fixes the following issues
- Fixes #482
- Finish PR https://github.com/voxpupuli/puppet-rundeck/pull/485