### PR TITLE
Allow to configure rundeck-config.properties, add new parameter custom_config and add enterprise key storage type cyberark et thycotic

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class rundeck::config {
   $auth_template                      = $rundeck::auth_template
   $auth_types                         = $rundeck::auth_types
   $clustermode_enabled                = $rundeck::clustermode_enabled
+  $custom_config                      = $rundeck::custom_config
   $database_config                    = $rundeck::database_config
   $execution_mode                     = $rundeck::execution_mode
   $file_default_mode                  = $rundeck::file_default_mode
@@ -52,6 +53,8 @@ class rundeck::config {
   $rd_loglevel                        = $rundeck::rd_loglevel
   $rd_auditlevel                      = $rundeck::rd_auditlevel
   $rdeck_config_template              = $rundeck::rdeck_config_template
+  $rdeck_config_template_type         = $rundeck::rdeck_config_template_type
+  $rdeck_config_type                  = $rundeck::rdeck_config_type
   $rdeck_home                         = $rundeck::rdeck_home
   $manage_home                        = $rundeck::manage_home
   $rdeck_profile_template             = $rundeck::rdeck_profile_template

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,9 @@
 # [*clustermode_enabled*]
 #  Boolean value if set to true enables cluster mode
 #
+# [*custom_config*]
+#  Hash of properties for customizing the rundeck-config file
+#
 # [*execution_mode*]
 #  If set, allows setting the execution mode to 'active' or 'passive'.
 #
@@ -75,7 +78,7 @@
 #  The default key password.
 #
 # [*key_storage_type*]
-#  Type used to store secrets. Must be 'file', 'db' or 'vault'
+#  Type used to store secrets. Must be 'cyberark', 'file', 'db', thycotic or 'vault'
 #
 # [*keystore*]
 #  Full path to the java keystore to be used by Rundeck.
@@ -135,6 +138,12 @@
 #
 # [*rdeck_config_template*]
 #  Allows you to override the rundeck-config template
+#
+# [*rdeck_config_template_type*]
+#  Format rdeck_config_template between epp and erb
+#
+# [*rdeck_config_type*]
+#  String value : set to groovy manage rundeck-config.groovy file or set to properties manage rundeck-config.properties file
 #
 # [*rdeck_home*]
 #  directory under which the projects directories live.
@@ -230,18 +239,19 @@ class rundeck (
   String $auth_template                                         = $rundeck::params::auth_template,
   Array $auth_types                                             = $rundeck::params::auth_types,
   Boolean $clustermode_enabled                                  = $rundeck::params::clustermode_enabled,
+  Hash $custom_config                                           = {},
   Hash $database_config                                         = $rundeck::params::database_config,
   Optional[Enum['active', 'passive']] $execution_mode           = undef,
   Stdlib::Absolutepath $file_keystorage_dir                     = $rundeck::params::file_keystorage_dir,
   Hash $file_keystorage_keys                                    = $rundeck::params::file_keystorage_keys,
   Hash $framework_config                                        = $rundeck::params::framework_config,
   Stdlib::HTTPUrl $grails_server_url                            = $rundeck::params::grails_server_url,
-  Hash $gui_config                                              = $rundeck::params::gui_config,
+  Hash $gui_config                                              = {},
   Optional[Stdlib::Absolutepath] $java_home                     = undef,
   String $jvm_args                                              = $rundeck::params::jvm_args,
   Hash $kerberos_realms                                         = $rundeck::params::kerberos_realms,
   String $key_password                                          = $rundeck::params::key_password,
-  Enum['db', 'file', 'vault'] $key_storage_type                 = $rundeck::params::key_storage_type,
+  Rundeck::KeyStorageType $key_storage_type                     = $rundeck::params::key_storage_type,
   Stdlib::Absolutepath $keystore                                = $rundeck::params::keystore,
   Optional[Stdlib::HTTPSUrl] $vault_keystorage_url              = undef,
   Optional[String[1]] $vault_keystorage_prefix                  = undef,
@@ -267,7 +277,9 @@ class rundeck (
   Integer $quartz_job_threadcount                               = $rundeck::params::quartz_job_threadcount,
   Rundeck::Loglevel $rd_loglevel                                = $rundeck::params::loglevel,
   Rundeck::Loglevel $rd_auditlevel                              = $rundeck::params::loglevel,
-  String $rdeck_config_template                                 = $rundeck::params::rdeck_config_template,
+  String $rdeck_config_template                                 = 'rundeck/rundeck-config.groovy.erb',
+  Enum['erb', 'epp'] $rdeck_config_template_type                = 'erb',
+  Enum['groovy','properties'] $rdeck_config_type                = 'groovy',
   Stdlib::Absolutepath $rdeck_home                              = $rundeck::params::rdeck_home,
   Boolean $manage_home                                          = $rundeck::params::manage_home,
   Optional[String] $rdeck_profile_template                      = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -284,7 +284,6 @@ class rundeck::params {
   $truststore_password = 'adminadmin'
 
   $resource_sources = {}
-  $gui_config = {}
 
   $preauthenticated_config = {
     'enabled'         => false,
@@ -311,8 +310,6 @@ class rundeck::params {
   $web_xml = "${rdeck_base}/exp/webapp/WEB-INF/web.xml"
   $security_role = 'user'
   $session_timeout = 30
-
-  $rdeck_config_template = 'rundeck/rundeck-config.erb'
 
   $file_keystorage_keys = {}
   $file_keystorage_dir = "${framework_config['framework.var.dir']}/storage"

--- a/spec/classes/config/global/custom_config.rb
+++ b/spec/classes/config/global/custom_config.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'rundeck' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          custom_config: {
+            'grails.plugin.databasemigration.updateOnStart' => true,
+            'rundeck.config.storage.converter.1.type' => 'jasypt-encryption',
+            'rundeck.config.storage.converter.1.path' => 'projects',
+            'rundeck.config.storage.converter.1.config.password' => 'default.encryption.password',
+            'rundeck.config.storage.converter.1.config.encryptorType' => 'custom',
+            'rundeck.config.storage.converter.1.config.algorithm' => 'PBEWITHSHA256AND128BITAES-CBC-BC',
+            'rundeck.config.storage.converter.1.config.provider' => 'BC'
+          }
+        }
+      end
+
+      # content and meta data for passwords
+      it 'generates custom_config content for rundeck-config.groovy' do
+        is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').
+          with_content(%r{grails\.plugin.databasemigration.updateOnStart=true}).
+          with_content(%r{rundeck\.config\.storage.converter\.1\.type=jasypt-encryption}).
+          with_content(%r{rundeck\.config\.storage.converter\.1\.path=projects}).
+          with_content(%r{rundeck\.config\.storage.converter\.1\.config\.password=default.encryption.password}).
+          with_content(%r{rundeck\.config\.storage.converter\.1\.config\.encryptorType=custom}).
+          with_content(%r{rundeck\.config\.storage.converter\.1\.config\.algorithm=PBEWITHSHA256AND128BITAES-CBC-BC}).
+          with_content(%r{rundeck\.config\.storage.converter\.1\.config\.provider=BC})
+      end
+    end
+  end
+end

--- a/spec/classes/config/global/rundeck_config_groovy_spec.rb
+++ b/spec/classes/config/global/rundeck_config_groovy_spec.rb
@@ -109,6 +109,7 @@ describe 'rundeck' do
           rundeck.security.authorization.preauthenticated.redirectLogout = "false"
           rundeck.security.authorization.preauthenticated.redirectUrl = "/oauth2/sign_in"
 
+
         CONFIG
 
         it { is_expected.to contain_file('/etc/rundeck/rundeck-config.groovy').with('content' => default_config) }

--- a/spec/classes/config/global/rundeck_config_properties_spec.rb
+++ b/spec/classes/config/global/rundeck_config_properties_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'rundeck' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} (properties file)" do
+      let :facts do
+        facts
+      end
+
+      describe "rundeck::config::global::rundeck_config class with use hmac request tokens parameter on #{os} (properties file)" do
+        value = true
+        security_hash = {
+          'useHMacRequestTokens' => value
+        }
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.useHMacRequestTokens=#{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with use api cookie access parameter on #{os} (properties file)" do
+        value = true
+        security_hash = {
+          'apiCookieAccess' => value
+        }
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.apiCookieAccess\.enabled=#{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with api tokens duration parameter on #{os} (properties file)" do
+        duration = '0'
+        security_hash = {
+          'apiTokensDuration' => duration
+        }
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.api\.tokens\.duration\.max=#{duration}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with csrf referrer filter method parameter on #{os} (properties file)" do
+        value = 'NONE'
+        security_hash = {
+          'csrfRefererFilterMethod' => value
+        }
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.csrf\.referer\.filterMethod=#{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with csrf referrer require https parameter on #{os} (properties file)" do
+        value = true
+        security_hash = {
+          'csrfRefererRequireHttps' => value
+        }
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', security_config: security_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.csrf\.referer\.requireHttps=#{value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with no security parameters on #{os} (properties file)" do
+        bool_value = true
+        filter_method_parameter = 'NONE'
+        duration = '0'
+        security_hash = {}
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', security_config: security_hash } }
+
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.useHMacRequestTokens=#{bool_value}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.apiCookieAccess\.enabled=#{bool_value}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.api\.tokens\.duration\.max=#{duration}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.csrf\.referer\.filterMethod=#{filter_method_parameter}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.csrf\.referer\.allowApi=#{bool_value}}) }
+        it { is_expected.not_to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.security\.csrf\.referer\.requireHttps=#{bool_value}}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class without any parameters on #{os} (properties file)" do
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp' } }
+
+        it {
+          is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').
+            with_content(%r{loglevel\.default=INFO}).
+            with_content(%r{rdeck\.base=/var/lib/rundeck}).
+            with_content(%r{log4j\.configurationFile=/etc/rundeck/log4j2.properties}).
+            with_content(%r{rundeck\.security\.useHMacRequestTokens=true}).
+            with_content(%r{dataSource\.dbCreate=update}).
+            with_content(%r{dataSource\.url=jdbc:h2:file:/var/lib/rundeck/data/rundeckdb;MVCC=true}).
+            with_content(%r{grails\.serverURL=http://foo.example.com:4440}).
+            with_content(%r{rundeck\.clusterMode\.enabled=false}).
+            with_content(%r{rundeck\.projectsStorageType=filesystem}).
+            with_content(%r{quartz\.threadPool\.threadCount=10}).
+            with_content(%r{rundeck\.storage\.provider\.1\.type=file})
+        }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with execution mode parameter 'active' on #{os} (properties file)" do
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', execution_mode: 'active' } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.executionMode=active}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with execution mode parameter 'passive' on #{os} (properties file)" do
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', execution_mode: 'passive' } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.executionMode=passive}) }
+      end
+
+      describe "rundeck::config::global::rundeck_config class with key storage encryption on #{os} (properties file)" do
+        storage_encrypt_config_hash = {
+          'type' => 'thetype',
+          'path' => '/storagepath',
+          'config.encryptionType' => 'basic',
+          'config.password' => 'verysecure'
+        }
+        let(:params) { { rdeck_config_template_type: 'epp', rdeck_config_type: 'properties', rdeck_config_template: 'rundeck/rundeck-config.properties.epp', storage_encrypt_config: storage_encrypt_config_hash } }
+
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.storage\.converter\.1\.type=thetype}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.storage\.converter\.1\.path=/storagepath}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.storage\.converter\.1\.config\.encryptionType=basic}) }
+        it { is_expected.to contain_file('/etc/rundeck/rundeck-config.properties').with_content(%r{rundeck\.storage\.converter\.1\.config\.password=verysecure}) }
+      end
+    end
+  end
+end

--- a/templates/rundeck-config.groovy.erb
+++ b/templates/rundeck-config.groovy.erb
@@ -81,8 +81,10 @@ rundeck.storage.provider."1".config.approleSecretId = "<%= @vault_keystorage_app
 rundeck.storage.provider."1".config.approleAuthMount = "<%= @vault_keystorage_approle_authmount %>"
 rundeck.storage.provider."1".config.authBackend = "<%= @vault_keystorage_authbackend %>"
 rundeck.storage.provider."1".removePathPrefix = true
-<%- else -%>
+<%- elsif @key_storage_type == 'db' -%>
 rundeck.storage.provider."1".type = "db"
+<%- else -%>
+rundeck.storage.provider."1".type = "<%= @key_storage_type %>-storage"
 <%- end -%>
 rundeck.storage.provider."1".path = "/"
 <%- if !@storage_encrypt_config.empty? -%>
@@ -97,5 +99,9 @@ rundeck.security.authorization.preauthenticated.<%= k %> = "<%= v %>"
 <%- end -%>
 
 <%- @gui_config.sort.each do |k,v| -%>
+<%= k %> = "<%= v %>"
+<%- end -%>
+
+<%- @custom_config.sort.each do |k,v| -%>
 <%= k %> = "<%= v %>"
 <%- end -%>

--- a/templates/rundeck-config.properties.epp
+++ b/templates/rundeck-config.properties.epp
@@ -1,0 +1,116 @@
+#loglevel.default is the default log level for jobs: ERROR,WARN,INFO,VERBOSE,DEBUG
+loglevel.default=<%= $rundeck::config::global::rundeck_config::rd_loglevel %>
+rdeck.base=<%= $rundeck::config::global::rundeck_config::rdeck_base %>
+log4j.configurationFile=<%= $rundeck::config::global::rundeck_config::properties_dir %>/log4j2.properties
+
+#rss.enabled if set to true enables RSS feeds that are public (non-authenticated)
+rss.enabled=<%= $rundeck::config::global::rundeck_config::rss_enabled %>
+
+grails.serverURL=<%= $rundeck::config::global::rundeck_config::grails_server_url %>
+
+rundeck.clusterMode.enabled=<%= $rundeck::config::global::rundeck_config::clustermode_enabled %>
+<%- if $rundeck::config::global::rundeck_config::execution_mode { -%>
+rundeck.executionMode=<%= $rundeck::config::global::rundeck_config::execution_mode %>
+<%- } -%>
+quartz.threadPool.threadCount=<%= $rundeck::config::global::rundeck_config::quartz_job_threadcount %>
+
+# Datasource
+dataSource.dbCreate=<%= $rundeck::config::global::rundeck_config::database_config['dbCreate'] %>
+dataSource.url=<%= $rundeck::config::global::rundeck_config::database_config['url'] %>
+<%- if $rundeck::config::global::rundeck_config::database_config['type'] != 'h2' { -%>
+dataSource.driverClassName=<%= $rundeck::config::global::rundeck_config::database_config['driverClassName'] %>
+dataSource.username=<%= $rundeck::config::global::rundeck_config::database_config['username'] %>
+dataSource.password=<%= $rundeck::config::global::rundeck_config::database_config['password'] %>
+dataSource.dialect=<%= $rundeck::config::global::rundeck_config::database_config['dialect'] %>
+<%- } -%>
+
+# Security
+<%- if $rundeck::config::global::rundeck_config::security_config['useHMacRequestTokens'] { -%>
+rundeck.security.useHMacRequestTokens=<%= $rundeck::config::global::rundeck_config::security_config['useHMacRequestTokens'] %>
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::security_config['apiCookieAccess'] { -%>
+rundeck.security.apiCookieAccess.enabled=<%= $rundeck::config::global::rundeck_config::security_config['apiCookieAccess'] %>
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::security_config['apiTokensDuration'] { -%>
+rundeck.api.tokens.duration.max=<%= $rundeck::config::global::rundeck_config::security_config['apiTokensDuration'] %>
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::security_config['csrfRefererFilterMethod'] { -%>
+rundeck.security.csrf.referer.filterMethod=<%= $rundeck::config::global::rundeck_config::security_config['csrfRefererFilterMethod'] %>
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::security_config['csrfRefererAllowApi'] { -%>
+rundeck.security.csrf.referer.allowApi=<%= $rundeck::config::global::rundeck_config::security_config['csrfRefererAllowApi'] %>
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::security_config['csrfRefererRequireHttps'] { -%>
+rundeck.security.csrf.referer.requireHttps=<%= $rundeck::config::global::rundeck_config::security_config['csrfRefererRequireHttps'] %>
+<%- } -%>
+
+# Encryption for key storage
+<%- if $rundeck::config::global::rundeck_config::key_storage_type == 'file' { -%>
+rundeck.storage.provider.1.type=file
+rundeck.storage.provider.1.config.baseDir=<%= $rundeck::config::global::rundeck_config::file_keystorage_dir %>
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::key_storage_type in ['cyberark', 'thycotic', 'vault'] { -%>
+rundeck.storage.provider.1.type=<%= $rundeck::config::global::rundeck_config::key_storage_type %>-storage
+rundeck.storage.provider.1.path=keys
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::key_storage_type == 'vault' { -%>
+rundeck.storage.provider.1.config.prefix=<%= $rundeck::config::global::rundeck_config::vault_keystorage_prefix %>
+rundeck.storage.provider.1.config.address=<%= $rundeck::config::global::rundeck_config::vault_keystorage_url %>
+rundeck.storage.provider.1.config.storageBehaviour=rundeck
+rundeck.storage.provider.1.config.secretBackend=kv
+rundeck.storage.provider.1.config.approleId=<%= $rundeck::config::global::rundeck_config::vault_keystorage_approle_approleid %>
+rundeck.storage.provider.1.config.approleSecretId=<%= $rundeck::config::global::rundeck_config::vault_keystorage_approle_secretid %>
+rundeck.storage.provider.1.config.approleAuthMount=<%= $rundeck::config::global::rundeck_config::vault_keystorage_approle_authmount %>
+rundeck.storage.provider.1.config.authBackend=<%= $rundeck::config::global::rundeck_config::vault_keystorage_authbackend %>
+rundeck.storage.provider.1.removePathPrefix=true
+<%- } -%>
+<%- if $rundeck::config::global::rundeck_config::key_storage_type == 'db' { -%>
+rundeck.storage.provider.1.type=db
+rundeck.storage.provider.1.path=keys
+<%- } -%>
+
+<%- $rundeck::config::global::rundeck_config::storage_encrypt_config.each | $k, $v | { -%>
+rundeck.storage.converter.1.<%= $k %>=<%= $v %>
+<%- } -%>
+
+# Encryption for project config storage
+rundeck.projectsStorageType=<%= $rundeck::config::global::rundeck_config::projects_storage_type %>
+
+<%- $rundeck::config::global::rundeck_config::preauthenticated_config.each | $k, $v | { -%>
+rundeck.security.authorization.preauthenticated.<%= $k %>=<%= $v %>
+<%- } -%>
+
+<%- if $rundeck::config::global::rundeck_config::mail_config { -%>
+# Mail
+  <%- if $rundeck::config::global::rundeck_config::mail_config['defaults.from'] { -%>
+grails.mail.default.from=<%= $rundeck::config::global::rundeck_config::mail_config['defaults.from'] %>
+  <%- } else { -%>
+    <%- if $rundeck::config::global::rundeck_config::mail_config['host'] { -%>
+grails.mail.host=<%= $rundeck::config::global::rundeck_config::mail_config['host'] %>
+    <%- } -%>
+    <%- if $rundeck::config::global::rundeck_config::mail_config['username'] { -%>
+grails.mail.username=<%= $rundeck::config::global::rundeck_config::mail_config['username'] %>
+    <%- } -%>
+    <%- if $rundeck::config::global::rundeck_config::mail_config['port'] { -%>
+grails.mail.port=<%= $rundeck::config::global::rundeck_config::mail_config['port'] %>
+    <%- } -%>
+    <%- if $rundeck::config::global::rundeck_config::mail_config['password'] { -%>
+grails.mail.password=<%= $rundeck::config::global::rundeck_config::mail_config['password'] %>
+    <%- } -%>
+    <%- if $rundeck::config::global::rundeck_config::mail_config['props'] { -%>
+      <% $rundeck::config::global::rundeck_config::mail_config['props'].each | $k, $v | { -%>
+grails.mail.props.<%= $k %>=<%= $v %>
+      <% } %>
+    <%- } -%>
+  <%- } -%>
+<%- } -%>
+
+# Gui config
+<%- $rundeck::config::global::rundeck_config::gui_config.each | $k, $v | { -%>
+<%= $k %>=<%= $v %>
+<%- } -%>
+
+# Custom config
+<%- $rundeck::config::global::rundeck_config::custom_config.each | $k, $v | { -%>
+<%= $k %>=<%= $v %>
+<%- } -%>

--- a/types/keystoragetype.pp
+++ b/types/keystoragetype.pp
@@ -1,0 +1,2 @@
+# Key Storage
+type Rundeck::KeyStorageType = Enum['cyberark', 'db', 'file', 'thycotic', 'vault']


### PR DESCRIPTION
#### Pull Request (PR) description

- Reference : https://docs.rundeck.com/docs/history/4_x/version-4.0.0.html#under-the-hood-updates
"Configuration through config.groovy will be deprecated in future versions. The primary use for this was advanced mail configuration, which is now supported by Configuration Management or rundeck-config.properties"

- Add parameters to use a template "rundeck-config.properties.epp"
- Add parameter custom_config (actually, my client use parameter gui_config)
- Add entreprise key storage type : cyberark and thycotic

#### This Pull Request (PR) fixes the following issues

- No one