### PR TITLE
Inisettings resolve deprecation: use namespaced `create_ini_settings` function

### DIFF
--- a/manifests/config/project.pp
+++ b/manifests/config/project.pp
@@ -178,5 +178,5 @@ define rundeck::config::project (
     require => File[$properties_file],
   }
 
-  create_ini_settings($node_executor_settings, $node_executor_settings_defaults)
+  inifile::create_ini_settings($node_executor_settings, $node_executor_settings_defaults)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.4.1 < 6.0.0"
+      "version_requirement": ">= 4.1.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/java_ks",


### PR DESCRIPTION
#### Pull Request (PR) description
Change the (now deprecated) create_ini_settings function to its namespaced alternative inifile::create_ini_settings and increase the minimal supported version of inifile dependency, to the first version where inifile::create_ini_settings was introduced. 

#### This Pull Request (PR) fixes the following issues
Fixes #496