### PR TITLE
Update key storage parameters and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,23 +114,53 @@ class { 'rundeck':
 }
 ```
 
-### Use HashiCorp vault as keystorage
+### Configure HashiCorp vault as keystorage
 
 An additional [Rundeck Vault plugin](https://github.com/rundeck-plugins/vault-storage/) is required.
 
 ```Puppet
 class { 'rundeck':
-  key_storage_type                   => 'vault',
-  vault_keystorage_url               => 'https://vault.example.com',
-  vault_keystorage_prefix            => 'rundeck',
-  vault_keystorage_approle_approleid => 'xxx-xxx-xxx-xxx-xxx',
-  vault_keystorage_approle_secretid  => 'xxx-xxx-xxx-xxx-xxx',
-  vault_keystorage_approle_authmount => 'approle',
-  vault_keystorage_authbackend       => 'approle',
+  key_storage_config => [
+    {
+      'type'   => 'vault-storage',
+      'path'   => '/',
+      'config' => {
+        'prefix'           => 'rundeck',
+        'address'          => 'https://vault.example.com',
+        'storageBehaviour' => 'vault',
+        'secretBackend'    => 'rundeck',
+        'engineVersion'    => '2',
+        'authBackend'      => 'approle',
+        'approleAuthMount' => 'approle',
+        'approleId'        => 'xxx-xxx-xxx-xxx-xxx',
+        'approleSecretId'  => 'xxx-xxx-xxx-xxx-xxx',
+      },
+    },
+  ],
 }
 ```
 
-### Configuring shared authentication credentials
+### Configure multiple keystorage types
+
+```Puppet
+class { 'rundeck':
+  key_storage_config => [
+    {
+      'type'   => 'file',
+      'path'   => '/keys',
+      'config' => {
+        'baseDir => '/path/to/dir',
+      },
+    },
+    {
+      'type' => 'db',
+      'path' => '/keys/database',
+    },
+  ],
+}
+```
+
+### Configure shared authentication credentials
 
 To perform LDAP authentication and file authorization following code can be used.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,12 @@ associated parameters.
 
 ```puppet
 class { 'rundeck':
-  key_storage_type      => 'db',
+  key_storage_config => [
+    {
+      'type' => 'db',
+      'path' => '/',
+    },
+  ],
   projects_storage_type => 'db',
   database_config       => {
     'type'            => 'mysql',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -70,15 +70,9 @@ The following parameters are available in the `rundeck` class:
 * [`jvm_args`](#-rundeck--jvm_args)
 * [`kerberos_realms`](#-rundeck--kerberos_realms)
 * [`key_password`](#-rundeck--key_password)
-* [`key_storage_type`](#-rundeck--key_storage_type)
+* [`key_storage_config`](#-rundeck--key_storage_config)
 * [`keystore`](#-rundeck--keystore)
 * [`keystore_password`](#-rundeck--keystore_password)
-* [`vault_keystorage_url`](#-rundeck--vault_keystorage_url)
-* [`vault_keystorage_prefix`](#-rundeck--vault_keystorage_prefix)
-* [`vault_keystorage_approle_approleid`](#-rundeck--vault_keystorage_approle_approleid)
-* [`vault_keystorage_approle_secretid`](#-rundeck--vault_keystorage_approle_secretid)
-* [`vault_keystorage_approle_authmount`](#-rundeck--vault_keystorage_approle_authmount)
-* [`vault_keystorage_authbackend`](#-rundeck--vault_keystorage_authbackend)
 * [`log_properties_template`](#-rundeck--log_properties_template)
 * [`mail_config`](#-rundeck--mail_config)
 * [`sshkey_manage`](#-rundeck--sshkey_manage)
@@ -286,13 +280,13 @@ The default key password.
 
 Default value: `$rundeck::params::key_password`
 
-##### <a name="-rundeck--key_storage_type"></a>`key_storage_type`
+##### <a name="-rundeck--key_storage_config"></a>`key_storage_config`
 
-Data type: `Enum['db', 'file', 'vault']`
+Data type: `Array[Hash]`
 
-Type used to store secrets. Must be 'file', 'db' or 'vault'
+An array with hashes of properties for customizing the [Rundeck Key Storage](https://docs.rundeck.com/docs/manual/key-storage/key-storage.html)
 
-Default value: `$rundeck::params::key_storage_type`
+Default value: `$rundeck::params::key_storage_config`
 
 ##### <a name="-rundeck--keystore"></a>`keystore`
 
@@ -309,54 +303,6 @@ Data type: `String`
 The password for the given keystore.
 
 Default value: `$rundeck::params::keystore_password`
-
-##### <a name="-rundeck--vault_keystorage_url"></a>`vault_keystorage_url`
-
-Data type: `Optional[Stdlib::HTTPSUrl]`
-
-A url to a HashiCorp vault instance.
-
-Default value: `undef`
-
-##### <a name="-rundeck--vault_keystorage_prefix"></a>`vault_keystorage_prefix`
-
-Data type: `Optional[String[1]]`
-
-HashiCorp vault kv path prefix.
-
-Default value: `undef`
-
-##### <a name="-rundeck--vault_keystorage_approle_approleid"></a>`vault_keystorage_approle_approleid`
-
-Data type: `Optional[String[1]]`
-
-HashiCorp vault approle role id.
-
-Default value: `undef`
-
-##### <a name="-rundeck--vault_keystorage_approle_secretid"></a>`vault_keystorage_approle_secretid`
-
-Data type: `Optional[String[1]]`
-
-HashiCorp vault approle secret id.
-
-Default value: `undef`
-
-##### <a name="-rundeck--vault_keystorage_approle_authmount"></a>`vault_keystorage_approle_authmount`
-
-Data type: `Optional[String[1]]`
-
-HashiCorp vault auth sys mount.
-
-Default value: `undef`
-
-##### <a name="-rundeck--vault_keystorage_authbackend"></a>`vault_keystorage_authbackend`
-
-Data type: `Optional[String[1]]`
-
-HashiCorp vault authentication backend.
-
-Default value: `undef`
 
 ##### <a name="-rundeck--log_properties_template"></a>`log_properties_template`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,12 +17,6 @@ class rundeck::config {
   $file_default_mode                  = $rundeck::file_default_mode
   $file_keystorage_dir                = $rundeck::file_keystorage_dir
   $file_keystorage_keys               = $rundeck::file_keystorage_keys
-  $vault_keystorage_prefix            = $rundeck::vault_keystorage_prefix
-  $vault_keystorage_url               = $rundeck::vault_keystorage_url
-  $vault_keystorage_approle_approleid = $rundeck::vault_keystorage_approle_approleid
-  $vault_keystorage_approle_secretid  = $rundeck::vault_keystorage_approle_secretid
-  $vault_keystorage_approle_authmount = $rundeck::vault_keystorage_approle_authmount
-  $vault_keystorage_authbackend       = $rundeck::vault_keystorage_authbackend
   $grails_server_url                  = $rundeck::grails_server_url
   $group                              = $rundeck::group
   $gui_config                         = $rundeck::gui_config
@@ -30,7 +24,7 @@ class rundeck::config {
   $jvm_args                           = $rundeck::jvm_args
   $kerberos_realms                    = $rundeck::kerberos_realms
   $key_password                       = $rundeck::key_password
-  $key_storage_type                   = $rundeck::key_storage_type
+  $key_storage_config                 = $rundeck::key_storage_config
   $keystore                           = $rundeck::keystore
   $keystore_password                  = $rundeck::keystore_password
   $log_properties_template            = $rundeck::log_properties_template

--- a/manifests/config/global/rundeck_config.pp
+++ b/manifests/config/global/rundeck_config.pp
@@ -8,16 +8,10 @@ class rundeck::config::global::rundeck_config {
   $clustermode_enabled                  = $rundeck::config::clustermode_enabled
   $execution_mode                       = $rundeck::config::execution_mode
   $file_keystorage_dir                  = $rundeck::config::file_keystorage_dir
-  $vault_keystorage_prefix              = $rundeck::config::vault_keystorage_prefix
-  $vault_keystorage_url                 = $rundeck::config::vault_keystorage_url
-  $vault_keystorage_approle_approleid   = $rundeck::config::vault_keystorage_approle_approleid
-  $vault_keystorage_approle_secretid    = $rundeck::config::vault_keystorage_approle_secretid
-  $vault_keystorage_approle_authmount   = $rundeck::config::vault_keystorage_approle_authmount
-  $vault_keystorage_authbackend         = $rundeck::config::vault_keystorage_authbackend
   $grails_server_url                    = $rundeck::config::grails_server_url
   $group                                = $rundeck::config::group
   $gui_config                           = $rundeck::config::gui_config
-  $key_storage_type                     = $rundeck::config::key_storage_type
+  $key_storage_config                   = $rundeck::config::key_storage_config
   $mail_config                          = $rundeck::config::mail_config
   $preauthenticated_config              = $rundeck::config::preauthenticated_config
   $projects_storage_type                = $rundeck::config::projects_storage_type

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,24 +38,12 @@
 #   A hash of mappings between Kerberos domain DNS names and realm names
 # @param key_password
 #   The default key password.
-# @param key_storage_type
-#   Type used to store secrets. Must be 'file', 'db' or 'vault'
+# @param key_storage_config
+#   An array with hashes of properties for customizing the [Rundeck Key Storage](https://docs.rundeck.com/docs/manual/key-storage/key-storage.html)
 # @param keystore
 #   Full path to the java keystore to be used by Rundeck.
 # @param keystore_password
 #   The password for the given keystore.
-# @param vault_keystorage_url
-#   A url to a HashiCorp vault instance.
-# @param vault_keystorage_prefix
-#   HashiCorp vault kv path prefix.
-# @param vault_keystorage_approle_approleid
-#   HashiCorp vault approle role id.
-# @param vault_keystorage_approle_secretid
-#   HashiCorp vault approle secret id.
-# @param vault_keystorage_approle_authmount
-#   HashiCorp vault auth sys mount.
-# @param vault_keystorage_authbackend
-#   HashiCorp vault authentication backend.
 # @param log_properties_template
 #   The template used for log properties. Default is rundeck/log4j.properties.erb.
 # @param mail_config
@@ -186,15 +174,9 @@ class rundeck (
   String                              $jvm_args                           = $rundeck::params::jvm_args,
   Hash                                $kerberos_realms                    = $rundeck::params::kerberos_realms,
   String                              $key_password                       = $rundeck::params::key_password,
-  Enum['db', 'file', 'vault']         $key_storage_type                   = $rundeck::params::key_storage_type,
+  Array[Hash]                         $key_storage_config                 = $rundeck::params::key_storage_config,
   Stdlib::Absolutepath                $keystore                           = $rundeck::params::keystore,
   String                              $keystore_password                  = $rundeck::params::keystore_password,
-  Optional[Stdlib::HTTPSUrl]          $vault_keystorage_url               = undef,
-  Optional[String[1]]                 $vault_keystorage_prefix            = undef,
-  Optional[String[1]]                 $vault_keystorage_approle_approleid = undef,
-  Optional[String[1]]                 $vault_keystorage_approle_secretid  = undef,
-  Optional[String[1]]                 $vault_keystorage_approle_authmount = undef,
-  Optional[String[1]]                 $vault_keystorage_authbackend       = undef,
   String                              $log_properties_template            = $rundeck::params::log_properties_template,
   Hash                                $mail_config                        = $rundeck::params::mail_config,
   Boolean                             $sshkey_manage                      = $rundeck::params::sshkey_manage,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -275,8 +275,19 @@ class rundeck::params {
 
   $kerberos_realms = {}
 
+  $file_keystorage_keys = {}
+  $file_keystorage_dir = "${framework_config['framework.var.dir']}/storage"
+
   $keystore = '/etc/rundeck/ssl/keystore'
-  $key_storage_type = 'file'
+  $key_storage_config = [
+    {
+      'type'   => 'file',
+      'path'   => '/',
+      'config' => {
+        'baseDir' => $file_keystorage_dir,
+      },
+    },
+  ]
   $projects_storage_type = 'filesystem'
   $keystore_password = 'adminadmin'
   $key_password = 'adminadmin'
@@ -313,9 +324,6 @@ class rundeck::params {
   $session_timeout = 30
 
   $rdeck_config_template = 'rundeck/rundeck-config.epp'
-
-  $file_keystorage_keys = {}
-  $file_keystorage_dir = "${framework_config['framework.var.dir']}/storage"
 
   $manage_default_admin_policy = true
   $manage_default_api_policy   = true

--- a/spec/classes/config/global/rundeck_config_spec.rb
+++ b/spec/classes/config/global/rundeck_config_spec.rb
@@ -98,8 +98,9 @@ describe 'rundeck' do
           quartz.threadPool.threadCount = "10"
 
           rundeck.storage.provider."1".type = "file"
-          rundeck.storage.provider."1".config.baseDir = "/var/lib/rundeck/var/storage"
           rundeck.storage.provider."1".path = "/"
+          rundeck.storage.provider."1".config.baseDir = "/var/lib/rundeck/var/storage"
+
 
           rundeck.security.authorization.preauthenticated.enabled = "false"
           rundeck.security.authorization.preauthenticated.attributeName = "REMOTE_USER_GROUPS"

--- a/templates/rundeck-config.epp
+++ b/templates/rundeck-config.epp
@@ -69,25 +69,19 @@ rundeck.executionMode = "<%= $rundeck::config::global::rundeck_config::execution
 rundeck.projectsStorageType = "<%= $rundeck::config::global::rundeck_config::projects_storage_type %>"
 quartz.threadPool.threadCount = "<%= $rundeck::config::global::rundeck_config::quartz_job_threadcount %>"
 
-<%- if $rundeck::config::global::rundeck_config::key_storage_type == 'file' {-%>
-rundeck.storage.provider."1".type = "file"
-rundeck.storage.provider."1".config.baseDir = "<%= $rundeck::config::global::rundeck_config::file_keystorage_dir %>"
-<%-} elsif $rundeck::config::global::rundeck_config::key_storage_type == 'vault' {-%>
-rundeck.storage.provider."1".type = "vault-storage"
-rundeck.storage.provider."1".path = "keys"
-rundeck.storage.provider."1".config.prefix = "<%= $rundeck::config::global::rundeck_config::vault_keystorage_prefix %>"
-rundeck.storage.provider."1".config.address = "<%= $rundeck::config::global::rundeck_config::vault_keystorage_url %>"
-rundeck.storage.provider."1".config.storageBehaviour = "rundeck"
-rundeck.storage.provider."1".config.secretBackend = "kv"
-rundeck.storage.provider."1".config.approleId = "<%= $rundeck::config::global::rundeck_config::vault_keystorage_approle_approleid %>"
-rundeck.storage.provider."1".config.approleSecretId = "<%= $rundeck::config::global::rundeck_config::vault_keystorage_approle_secretid %>"
-rundeck.storage.provider."1".config.approleAuthMount = "<%= $rundeck::config::global::rundeck_config::vault_keystorage_approle_authmount %>"
-rundeck.storage.provider."1".config.authBackend = "<%= $rundeck::config::global::rundeck_config::vault_keystorage_authbackend %>"
-rundeck.storage.provider."1".removePathPrefix = true
-<%-} else {-%>
-rundeck.storage.provider."1".type = "db"
+<%- $rundeck::config::global::rundeck_config::key_storage_config.each |$i, $cfg| { -%>
+rundeck.storage.provider."<%= $i+1 %>".type = "<%= $cfg['type'] %>"
+rundeck.storage.provider."<%= $i+1 %>".path = "<%= $cfg['path'] %>"
+<%- if $cfg['removePathPrefix'] { -%>
+rundeck.storage.provider."<%= $i+1 %>".removePathPrefix = <%= $cfg['removePathPrefix'] %>
 <%- } -%>
-rundeck.storage.provider."1".path = "/"
+<%- if $cfg['config'] { -%>
+<%- $cfg['config'].each |$k, $v| { -%>
+rundeck.storage.provider."<%= $i+1 %>".config.<%= $k %> = "<%= $v %>"
+<%- } -%>
+<%- } -%>
+<%- } -%>
+
 <%- if !$rundeck::config::global::rundeck_config::storage_encrypt_config.empty { -%>
 
   <%- $rundeck::config::global::rundeck_config::storage_encrypt_config.keys.sort.each |$k| { -%>


### PR DESCRIPTION
#### Pull Request (PR) description
The key storage type parameter limits the key storage entries to one.
It would be better to simplify this to one configurable hash.
Also remove vault specific parameters to limit breaking changes when vault-storage plugin updates config on their side.
Update docs as well.

