### PR TITLE
Avoid service restarts on configuration changes and allow "resourcejson" as resource format.

### DIFF
--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -71,37 +71,37 @@
 # @param puppet_enterprise_tag_source
 #   The Puppet Enterprise tag source.
 #
-define rundeck::config::resource_source(
-  Stdlib::Absolutepath $directory                                      = $rundeck::params::default_resource_dir,
-  Boolean $include_server_node                                         = $rundeck::params::include_server_node,
-  String $mapping_params                                               = '',
-  Integer $number                                                      = 1,
-  Optional[String] $project_name                                       = undef,
-  Enum['resourcexml', 'resourceyaml', 'resourcejson'] $resource_format = $rundeck::params::resource_format,
-  Boolean $running_only                                                = true,
-  String $script_args                                                  = '',
-  Boolean $script_args_quoted                                          = $rundeck::params::script_args_quoted,
-  Optional[Stdlib::Absolutepath] $script_file                          = undef,
-  String $script_interpreter                                           = $rundeck::params::script_interpreter,
-  Rundeck::Sourcetype $source_type                                     = $rundeck::params::default_source_type,
-  String $url                                                          = '',
-  Boolean $url_cache                                                   = $rundeck::params::url_cache,
-  Integer $url_timeout                                                 = $rundeck::params::url_timeout,
-  Boolean $use_default_mapping                                         = true,
-  Optional[String] $endpoint_url                                       = undef,
-  Optional[String[1]] $assume_role_arn                                 = undef,
-  String $filter_tag                                                   = '',
-  Stdlib::Port $http_proxy_port                                        = $rundeck::params::default_http_proxy_port,
-  Integer $refresh_interval                                            = $rundeck::params::default_refresh_interval,
-  Optional[String] $puppet_enterprise_host                             = undef,
-  Optional[Stdlib::Port] $puppet_enterprise_port                       = undef,
-  Optional[Stdlib::Absolutepath] $puppet_enterprise_ssl_dir            = undef,
-  Optional[String] $puppet_enterprise_certificate_name                 = undef,
-  Optional[Stdlib::Absolutepath] $puppet_enterprise_mapping_file       = undef,
-  Optional[Integer] $puppet_enterprise_metrics_interval                = undef,
-  Optional[String] $puppet_enterprise_node_query                       = undef,
-  Optional[String] $puppet_enterprise_default_node_tag                 = undef,
-  Optional[String] $puppet_enterprise_tag_source                       = undef,
+define rundeck::config::resource_source (
+  Stdlib::Absolutepath                                $directory                          = $rundeck::params::default_resource_dir,
+  Boolean                                             $include_server_node                = $rundeck::params::include_server_node,
+  String                                              $mapping_params                     = '', # lint:ignore:params_empty_string_assignment
+  Integer                                             $number                             = 1,
+  Optional[String]                                    $project_name                       = undef,
+  Enum['resourcexml', 'resourceyaml', 'resourcejson'] $resource_format                    = $rundeck::params::resource_format,
+  Boolean                                             $running_only                       = true,
+  String                                              $script_args                        = '', # lint:ignore:params_empty_string_assignment
+  Boolean                                             $script_args_quoted                 = $rundeck::params::script_args_quoted,
+  Optional[Stdlib::Absolutepath]                      $script_file                        = undef,
+  String                                              $script_interpreter                 = $rundeck::params::script_interpreter,
+  Rundeck::Sourcetype                                 $source_type                        = $rundeck::params::default_source_type,
+  String                                              $url                                = '', # lint:ignore:params_empty_string_assignment
+  Boolean                                             $url_cache                          = $rundeck::params::url_cache,
+  Integer                                             $url_timeout                        = $rundeck::params::url_timeout,
+  Boolean                                             $use_default_mapping                = true,
+  Optional[String]                                    $endpoint_url                       = undef,
+  Optional[String[1]]                                 $assume_role_arn                    = undef,
+  String                                              $filter_tag                         = '', # lint:ignore:params_empty_string_assignment
+  Stdlib::Port                                        $http_proxy_port                    = $rundeck::params::default_http_proxy_port,
+  Integer                                             $refresh_interval                   = $rundeck::params::default_refresh_interval,
+  Optional[String]                                    $puppet_enterprise_host             = undef,
+  Optional[Stdlib::Port]                              $puppet_enterprise_port             = undef,
+  Optional[Stdlib::Absolutepath]                      $puppet_enterprise_ssl_dir          = undef,
+  Optional[String]                                    $puppet_enterprise_certificate_name = undef,
+  Optional[Stdlib::Absolutepath]                      $puppet_enterprise_mapping_file     = undef,
+  Optional[Integer]                                   $puppet_enterprise_metrics_interval = undef,
+  Optional[String]                                    $puppet_enterprise_node_query       = undef,
+  Optional[String]                                    $puppet_enterprise_default_node_tag = undef,
+  Optional[String]                                    $puppet_enterprise_tag_source       = undef,
 ) {
   include rundeck
 

--- a/manifests/config/resource_source.pp
+++ b/manifests/config/resource_source.pp
@@ -71,37 +71,37 @@
 # @param puppet_enterprise_tag_source
 #   The Puppet Enterprise tag source.
 #
-define rundeck::config::resource_source (
-  Stdlib::Absolutepath                $directory                          = $rundeck::params::default_resource_dir,
-  Boolean                             $include_server_node                = $rundeck::params::include_server_node,
-  String                              $mapping_params                     = '', # lint:ignore:params_empty_string_assignment
-  Integer                             $number                             = 1,
-  Optional[String]                    $project_name                       = undef,
-  Enum['resourcexml', 'resourceyaml'] $resource_format                    = $rundeck::params::resource_format,
-  Boolean                             $running_only                       = true,
-  String                              $script_args                        = '', # lint:ignore:params_empty_string_assignment
-  Boolean                             $script_args_quoted                 = $rundeck::params::script_args_quoted,
-  Optional[Stdlib::Absolutepath]      $script_file                        = undef,
-  String                              $script_interpreter                 = $rundeck::params::script_interpreter,
-  Rundeck::Sourcetype                 $source_type                        = $rundeck::params::default_source_type,
-  String                              $url                                = '', # lint:ignore:params_empty_string_assignment
-  Boolean                             $url_cache                          = $rundeck::params::url_cache,
-  Integer                             $url_timeout                        = $rundeck::params::url_timeout,
-  Boolean                             $use_default_mapping                = true,
-  Optional[String]                    $endpoint_url                       = undef,
-  Optional[String[1]]                 $assume_role_arn                    = undef,
-  String                              $filter_tag                         = '', # lint:ignore:params_empty_string_assignment
-  Stdlib::Port                        $http_proxy_port                    = $rundeck::params::default_http_proxy_port,
-  Integer                             $refresh_interval                   = $rundeck::params::default_refresh_interval,
-  Optional[String]                    $puppet_enterprise_host             = undef,
-  Optional[Stdlib::Port]              $puppet_enterprise_port             = undef,
-  Optional[Stdlib::Absolutepath]      $puppet_enterprise_ssl_dir          = undef,
-  Optional[String]                    $puppet_enterprise_certificate_name = undef,
-  Optional[Stdlib::Absolutepath]      $puppet_enterprise_mapping_file     = undef,
-  Optional[Integer]                   $puppet_enterprise_metrics_interval = undef,
-  Optional[String]                    $puppet_enterprise_node_query       = undef,
-  Optional[String]                    $puppet_enterprise_default_node_tag = undef,
-  Optional[String]                    $puppet_enterprise_tag_source       = undef,
+define rundeck::config::resource_source(
+  Stdlib::Absolutepath $directory                                      = $rundeck::params::default_resource_dir,
+  Boolean $include_server_node                                         = $rundeck::params::include_server_node,
+  String $mapping_params                                               = '',
+  Integer $number                                                      = 1,
+  Optional[String] $project_name                                       = undef,
+  Enum['resourcexml', 'resourceyaml', 'resourcejson'] $resource_format = $rundeck::params::resource_format,
+  Boolean $running_only                                                = true,
+  String $script_args                                                  = '',
+  Boolean $script_args_quoted                                          = $rundeck::params::script_args_quoted,
+  Optional[Stdlib::Absolutepath] $script_file                          = undef,
+  String $script_interpreter                                           = $rundeck::params::script_interpreter,
+  Rundeck::Sourcetype $source_type                                     = $rundeck::params::default_source_type,
+  String $url                                                          = '',
+  Boolean $url_cache                                                   = $rundeck::params::url_cache,
+  Integer $url_timeout                                                 = $rundeck::params::url_timeout,
+  Boolean $use_default_mapping                                         = true,
+  Optional[String] $endpoint_url                                       = undef,
+  Optional[String[1]] $assume_role_arn                                 = undef,
+  String $filter_tag                                                   = '',
+  Stdlib::Port $http_proxy_port                                        = $rundeck::params::default_http_proxy_port,
+  Integer $refresh_interval                                            = $rundeck::params::default_refresh_interval,
+  Optional[String] $puppet_enterprise_host                             = undef,
+  Optional[Stdlib::Port] $puppet_enterprise_port                       = undef,
+  Optional[Stdlib::Absolutepath] $puppet_enterprise_ssl_dir            = undef,
+  Optional[String] $puppet_enterprise_certificate_name                 = undef,
+  Optional[Stdlib::Absolutepath] $puppet_enterprise_mapping_file       = undef,
+  Optional[Integer] $puppet_enterprise_metrics_interval                = undef,
+  Optional[String] $puppet_enterprise_node_query                       = undef,
+  Optional[String] $puppet_enterprise_default_node_tag                 = undef,
+  Optional[String] $puppet_enterprise_tag_source                       = undef,
 ) {
   include rundeck
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -238,7 +238,13 @@ class rundeck (
   contain rundeck::config
   contain rundeck::service
 
-  Class['rundeck::install']
-  -> Class['rundeck::config']
-  ~> Class['rundeck::service']
+  if $service_restart {
+    Class['rundeck::install']
+    -> Class['rundeck::config']
+    ~> Class['rundeck::service']
+  } else {
+    Class['rundeck::install']
+    -> Class['rundeck::config']
+    -> Class['rundeck::service']
+  }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
Allow resource_format "resourcejson" as well, as it's allowed and working with rundeck.

Fix PR #486 to really avoid service restarts on configuration changes.
#### This Pull Request (PR) fixes the following issues
n/a
