### PR TITLE
Remove command opt which caused an infinite loop

### DIFF
--- a/manifests/config/project.pp
+++ b/manifests/config/project.pp
@@ -75,7 +75,7 @@ define rundeck::config::project (
     }
 
     exec { "Create/update rundeck job: ${_name}":
-      command     => "rd jobs load -r -d update -p '${name}' -f '${_attr['path']}' -F ${_attr['format']}",
+      command     => "rd jobs load -d update -p '${name}' -f '${_attr['path']}' -F ${_attr['format']}",
       path        => ['/bin', '/usr/bin', '/usr/local/bin'],
       environment => $rundeck::cli::environment,
       unless      => "rd_job_diff.sh '${name}' '${_name}' '${_attr['path']}' ${_attr['format']}",


### PR DESCRIPTION
#### Pull Request (PR) description
This PR will remove the command option -r for the job creation.
This is because the option -r removes uuid when uploading the job file, which will cause an infinite diff loop with the original file.
