### PR TITLE
Avoid duplicate resources by including project name

### DIFF
--- a/manifests/config/project.pp
+++ b/manifests/config/project.pp
@@ -66,14 +66,14 @@ define rundeck::config::project (
 
   $jobs.each |$_name, $_attr| {
     if $_attr['ensure'] == 'absent' {
-      exec { "Remove rundeck job: ${_name}":
+      exec { "(${name}) Remove job: ${_name}":
         command     => "rd jobs purge -y -p '${name}' -J '${_name}'",
         path        => ['/bin', '/usr/bin', '/usr/local/bin'],
         environment => $rundeck::cli::environment,
         onlyif      => "rd jobs list -p '${name}' -J '${_name}' | grep -q '${_name}'",
       }
     } else {
-      exec { "Create/update rundeck job: ${_name}":
+      exec { "(${name}) Create/update job: ${_name}":
         command     => "rd jobs load -d update -p '${name}' -f '${_attr['path']}' -F ${_attr['format']}",
         path        => ['/bin', '/usr/bin', '/usr/local/bin'],
         environment => $rundeck::cli::environment,

--- a/spec/classes/cli_spec.rb
+++ b/spec/classes/cli_spec.rb
@@ -140,6 +140,9 @@ describe 'rundeck::cli' do
           )
         end
 
+        it { is_expected.to contain_exec('(MyProject) Create/update job: MyJob1') }
+        it { is_expected.to contain_exec('(MyProject) Create/update job: MyJob2') }
+
         it do
           is_expected.to contain_rundeck__config__project('TestProject').with(
             config: {
@@ -154,6 +157,8 @@ describe 'rundeck::cli' do
             }
           )
         end
+
+        it { is_expected.to contain_exec('(TestProject) Create/update job: TestJob1') }
       end
     end
   end

--- a/spec/defines/config/project_spec.rb
+++ b/spec/defines/config/project_spec.rb
@@ -127,10 +127,10 @@ describe 'rundeck::config::project', type: :define do
 
         it { is_expected.to contain_exec('Create rundeck project: MyJobProject') }
         it { is_expected.to contain_exec('Manage rundeck project: MyJobProject') }
-        it { is_expected.to contain_exec('Create/update rundeck job: MyJob1') }
-        it { is_expected.to contain_exec('Create/update rundeck job: MyJob2') }
-        it { is_expected.to contain_exec('Create/update rundeck job: TestJob1') }
-        it { is_expected.to contain_exec('Remove rundeck job: DeleteJob1') }
+        it { is_expected.to contain_exec('(MyJobProject) Create/update job: MyJob1') }
+        it { is_expected.to contain_exec('(MyJobProject) Create/update job: MyJob2') }
+        it { is_expected.to contain_exec('(MyJobProject) Create/update job: TestJob1') }
+        it { is_expected.to contain_exec('(MyJobProject) Remove job: DeleteJob1') }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
To avoid duplicate job resources, the project name is included in the job exec
