### PR TITLE
fix: `framework.logs.dir` path

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class rundeck::config {
     'framework.etc.dir'         => '/etc/rundeck',
     'framework.var.dir'         => '/var/lib/rundeck/var',
     'framework.tmp.dir'         => '/var/lib/rundeck/var/tmp',
-    'framework.logs.dir'        => '/var/lib/rundeck/var/logs',
+    'framework.logs.dir'        => '/var/lib/rundeck/logs',
     'framework.libext.dir'      => '/var/lib/rundeck/libext',
     'framework.ssh.keypath'     => '/var/lib/rundeck/.ssh/id_rsa',
     'framework.ssh.user'        => 'rundeck',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -18,7 +18,7 @@ describe 'rundeck' do
         it { is_expected.to contain_file('/etc/rundeck').with(ensure: 'directory') }
         it { is_expected.to contain_file('/var/lib/rundeck/var').with(ensure: 'directory') }
         it { is_expected.to contain_file('/var/lib/rundeck/var/tmp').with(ensure: 'directory') }
-        it { is_expected.to contain_file('/var/lib/rundeck/var/logs').with(ensure: 'directory') }
+        it { is_expected.to contain_file('/var/lib/rundeck/logs').with(ensure: 'directory') }
 
         it { is_expected.to contain_file('/var/log/rundeck').with(ensure: 'directory') }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Correct `framework.logs.dir` path.

#### This Pull Request (PR) fixes the following issues

Fixes #547 
